### PR TITLE
Base recycle penalty on dealt draw mode

### DIFF
--- a/ComputerSolitaire/Game/Klondike/GameSessionKlondike.swift
+++ b/ComputerSolitaire/Game/Klondike/GameSessionKlondike.swift
@@ -162,7 +162,7 @@ extension SolitaireViewModel {
         state.waste.removeAll()
         setWasteDrawCount(0)
         incrementMovesCount()
-        if stockDrawCount == DrawMode.one.rawValue {
+        if scoringDrawCount == DrawMode.one.rawValue {
             applyScore(.recycleWasteInDrawOne)
         }
         SoundManager.shared.play(.wasteRecycleToStock)

--- a/ComputerSolitaire/Game/Shared/GameSession.swift
+++ b/ComputerSolitaire/Game/Shared/GameSession.swift
@@ -40,7 +40,7 @@ final class SolitaireViewModel {
     private(set) var finalElapsedSeconds: Int?
     private var pauseStartedAt: Date?
     private(set) var stockDrawCount: Int = 3
-    private var scoringDrawCount: Int = DrawMode.three.rawValue
+    private(set) var scoringDrawCount: Int = DrawMode.three.rawValue
     private var hasStartedTrackedGame = false
     private var isCurrentGameFinalized = false
     private var hintRequestsInCurrentGame: Int = 0

--- a/ComputerSolitaireTests/Shared/SolitaireViewModelCoreTests.swift
+++ b/ComputerSolitaireTests/Shared/SolitaireViewModelCoreTests.swift
@@ -65,6 +65,44 @@ final class SolitaireViewModelCoreTests: XCTestCase {
         XCTAssertTrue(viewModel.state.stock.allSatisfy { !$0.isFaceUp })
     }
 
+    func testRecyclePenaltyAppliesWhenDealtDrawOneEvenAfterSwitchingToDrawThree() {
+        var state = GameStateFixtures.validPersistenceState()
+        state.waste = state.stock.map { card in
+            var faceUp = card
+            faceUp.isFaceUp = true
+            return faceUp
+        }
+        state.stock = []
+        state.wasteDrawCount = min(1, state.waste.count)
+        let viewModel = makeViewModel(
+            restoring: payload(state: state, stockDrawCount: DrawMode.one.rawValue, score: 150)
+        )
+
+        viewModel.updateDrawMode(.three)
+        viewModel.handleStockTap()
+
+        XCTAssertEqual(viewModel.score, 150 + Scoring.delta(for: .recycleWasteInDrawOne))
+    }
+
+    func testRecycleHasNoPenaltyWhenDealtDrawThreeEvenAfterSwitchingToDrawOne() {
+        var state = GameStateFixtures.validPersistenceState()
+        state.waste = state.stock.map { card in
+            var faceUp = card
+            faceUp.isFaceUp = true
+            return faceUp
+        }
+        state.stock = []
+        state.wasteDrawCount = min(3, state.waste.count)
+        let viewModel = makeViewModel(
+            restoring: payload(state: state, stockDrawCount: DrawMode.three.rawValue, score: 150)
+        )
+
+        viewModel.updateDrawMode(.one)
+        viewModel.handleStockTap()
+
+        XCTAssertEqual(viewModel.score, 150)
+    }
+
     func testStartDragCanDropAndHandleDropMoveWasteToFoundation() {
         let aceSpades = TestCards.make(.spades, .ace, isFaceUp: true)
         let state = makeValidState(
@@ -168,6 +206,7 @@ final class SolitaireViewModelCoreTests: XCTestCase {
         state: GameState,
         savedAt: Date = DateFixtures.reference,
         stockDrawCount: Int,
+        score: Int = 0,
         gameStartedAt: Date = DateFixtures.reference,
         pauseStartedAt: Date? = nil
     ) -> SavedGamePayload {
@@ -175,7 +214,7 @@ final class SolitaireViewModelCoreTests: XCTestCase {
             savedAt: savedAt,
             state: state,
             movesCount: 0,
-            score: 0,
+            score: score,
             gameStartedAt: gameStartedAt,
             pauseStartedAt: pauseStartedAt,
             hasAppliedTimeBonus: false,


### PR DESCRIPTION
The draw-one recycle penalty checked the live `stockDrawCount`, while the time bonus and statistics use `scoringDrawCount` (frozen at deal/redeal). Switching draw modes mid-game let the two disagree — e.g. toggling to 3-card draw right before each recycle dodged the −100 penalty while still playing (and being scored as) a 1-card draw game.

The penalty now keys off `scoringDrawCount` so all scoring rules agree on the dealt mode.

- `recycleWaste()` checks `scoringDrawCount` instead of `stockDrawCount`
- `scoringDrawCount` exposed as `private(set)` (matches `stockDrawCount`)
- regression tests for mid-game switches in both directions
