### PR TITLE
Update GitHub actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Run unit tests (macOS)
         run: |
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload test result bundle on failure
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: macos-test-results
           path: ${{ runner.temp }}/ComputerSolitaireTests.xcresult
@@ -47,7 +47,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Build app (iOS Simulator)
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Import Apple signing certificate
         env:


### PR DESCRIPTION
Updates GitHub Actions dependencies to versions that run on Node 24.

This removes Node 20 deprecation warnings from CI and release workflows.
