### PR TITLE
Add iOS About page

### DIFF
--- a/ComputerSolitaire/Views/AboutView.swift
+++ b/ComputerSolitaire/Views/AboutView.swift
@@ -1,83 +1,135 @@
-#if os(macOS)
+import Foundation
 import SwiftUI
 
+enum AppInfo {
+    static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+    static let copyrightYear = String(Calendar.current.component(.year, from: Date()))
+    static let githubURL = URL(string: "https://github.com/austin-smith/ComputerSolitaire")!
+}
+
+private enum AboutViewMetrics {
+#if os(iOS)
+    static let iconSize: CGFloat = 100
+    static let iconCornerRadius: CGFloat = 22
+    static let contentSpacing: CGFloat = 16
+    static let titleFont = Font.system(.title2, design: .monospaced, weight: .bold)
+    static let taglineFont = Font.subheadline.weight(.medium)
+    static let descriptionFont = Font.subheadline
+    static let versionFont = Font.subheadline.weight(.medium)
+    static let copyrightFont = Font.caption
+#else
+    static let iconSize: CGFloat = 128
+    static let iconCornerRadius: CGFloat = 22
+    static let contentSpacing: CGFloat = 12
+    static let titleFont = Font.system(size: 22, weight: .bold, design: .monospaced)
+    static let taglineFont = Font.system(size: 13, weight: .medium)
+    static let descriptionFont = Font.system(size: 11)
+    static let versionFont = Font.system(size: 11, weight: .medium)
+    static let copyrightFont = Font.system(size: 10)
+#endif
+}
+
 struct AboutView: View {
-    @Environment(\.openURL) private var openURL
-
-    private var appVersion: String {
-        Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
-    }
-
-    private var copyrightYear: String {
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy"
-        return formatter.string(from: Date())
-    }
-
     var body: some View {
-        VStack(spacing: 12) {
-            VStack(spacing: 12) {
-                Image(nsImage: NSApp.applicationIconImage)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 128, height: 128)
-                    .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
-                    .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+#if os(iOS)
+        ScrollView {
+            aboutContent
+                .frame(maxWidth: .infinity)
+                .padding(.horizontal, 24)
+                .padding(.top, 32)
+                .padding(.bottom, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .navigationTitle("About")
+        .navigationBarTitleDisplayMode(.inline)
+#else
+        aboutContent
+            .padding(.horizontal, 28)
+            .padding(.vertical, 24)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(.regularMaterial)
+#endif
+    }
 
-                VStack(spacing: 4) {
-                    Text("Computer Solitaire")
-                        .font(.system(size: 22, weight: .bold, design: .monospaced))
+    private var aboutContent: some View {
+        VStack(spacing: AboutViewMetrics.contentSpacing) {
+            Image("AppIconPreviewDefault")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .frame(
+                    width: AboutViewMetrics.iconSize,
+                    height: AboutViewMetrics.iconSize
+                )
+                .clipShape(
+                    .rect(
+                        cornerRadius: AboutViewMetrics.iconCornerRadius,
+                        style: .continuous
+                    )
+                )
+                .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+                .accessibilityHidden(true)
+
+            VStack(spacing: 4) {
+                Text("Computer Solitaire")
+                    .font(AboutViewMetrics.titleFont)
+                    .foregroundStyle(.primary)
+
+                Text(tagline)
+                    .font(AboutViewMetrics.taglineFont)
+                    .foregroundStyle(.secondary)
+            }
+            .multilineTextAlignment(.center)
+            .fixedSize(horizontal: false, vertical: true)
+
+            Text("Computer Solitaire is a low-frills, ad-free solitaire game for your computer. Includes Klondike, FreeCell, and other things you enjoy.")
+                .font(AboutViewMetrics.descriptionFont)
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+#if os(iOS)
+                .padding(.horizontal, 8)
+#endif
+
+            VStack(spacing: 2) {
+                HStack(spacing: 8) {
+                    Text("Version")
+                        .foregroundStyle(.secondary)
+                    Text(AppInfo.version)
+                        .fontDesign(.monospaced)
                         .foregroundStyle(.primary)
                 }
+                .font(AboutViewMetrics.versionFont)
+
+                Text("© \(AppInfo.copyrightYear) Austin Smith")
+                    .font(AboutViewMetrics.copyrightFont)
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 12)
             }
-
-            VStack(spacing: 16) {
-                Text("Fully native solitaire game for your computer.")
-                    .font(.system(size: 11))
-                    .foregroundStyle(.secondary)
-                    .multilineTextAlignment(.center)
-                    .lineLimit(nil)
-                    .fixedSize(horizontal: false, vertical: true)
-
-                VStack(spacing: 2) {
-                    HStack(spacing: 8) {
-                        Text("Version")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundStyle(.secondary)
-                        Text(appVersion)
-                            .font(.system(size: 11, weight: .medium, design: .monospaced))
-                            .foregroundStyle(.primary)
-                    }
-
-                    Text("© \(copyrightYear) Austin Smith")
-                        .font(.system(size: 10))
-                        .foregroundStyle(.tertiary)
-                        .padding(.top, 12)
-                }
-            }
+            .accessibilityElement(children: .combine)
 
             VStack(spacing: 8) {
-                Button {
-                    guard let url = URL(string: "https://github.com/austin-smith/ComputerSolitaire") else { return }
-                    openURL(url)
-                } label: {
-                    Text("GitHub")
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.regular)
-            }
+                Divider()
+                    .padding(.horizontal, 24)
 
+                Link("GitHub", destination: AppInfo.githubURL)
+                    .buttonStyle(.bordered)
+                    .controlSize(.regular)
+            }
         }
-        .padding(.horizontal, 28)
-        .padding(.vertical, 24)
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 0))
+    }
+
+    private var tagline: String {
+        "Fully native solitaire game for your computer."
     }
 }
 
-#Preview("About Us") {
+#Preview("About") {
+#if os(iOS)
+    NavigationStack {
+        AboutView()
+    }
+#else
     AboutView()
         .frame(width: 320, height: 380)
-}
-
 #endif
+}

--- a/ComputerSolitaire/Views/AboutView.swift
+++ b/ComputerSolitaire/Views/AboutView.swift
@@ -1,135 +1,163 @@
 import Foundation
 import SwiftUI
 
+#if os(iOS)
 enum AppInfo {
     static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
     static let copyrightYear = String(Calendar.current.component(.year, from: Date()))
     static let githubURL = URL(string: "https://github.com/austin-smith/ComputerSolitaire")!
 }
 
-private enum AboutViewMetrics {
-#if os(iOS)
-    static let iconSize: CGFloat = 100
-    static let iconCornerRadius: CGFloat = 22
-    static let contentSpacing: CGFloat = 16
-    static let titleFont = Font.system(.title2, design: .monospaced, weight: .bold)
-    static let taglineFont = Font.subheadline.weight(.medium)
-    static let descriptionFont = Font.subheadline
-    static let versionFont = Font.subheadline.weight(.medium)
-    static let copyrightFont = Font.caption
-#else
-    static let iconSize: CGFloat = 128
-    static let iconCornerRadius: CGFloat = 22
-    static let contentSpacing: CGFloat = 12
-    static let titleFont = Font.system(size: 22, weight: .bold, design: .monospaced)
-    static let taglineFont = Font.system(size: 13, weight: .medium)
-    static let descriptionFont = Font.system(size: 11)
-    static let versionFont = Font.system(size: 11, weight: .medium)
-    static let copyrightFont = Font.system(size: 10)
-#endif
-}
-
 struct AboutView: View {
     var body: some View {
-#if os(iOS)
         ScrollView {
-            aboutContent
-                .frame(maxWidth: .infinity)
-                .padding(.horizontal, 24)
-                .padding(.top, 32)
-                .padding(.bottom, 40)
+            VStack(spacing: 16) {
+                Image("AppIconPreviewDefault")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 100, height: 100)
+                    .clipShape(.rect(cornerRadius: 22, style: .continuous))
+                    .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+                    .accessibilityHidden(true)
+
+                VStack(spacing: 4) {
+                    Text("Computer Solitaire")
+                        .font(.system(size: 24, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.primary)
+
+                    Text("Solitaire game for your computer")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+
+                Text("Computer Solitaire is a low-frills, ad-free solitaire game for your computer. Includes Klondike, FreeCell, and other things you enjoy.")
+                    .font(.system(size: 14))
+                    .foregroundStyle(.primary)
+                    .multilineTextAlignment(.center)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .padding(.horizontal, 24)
+
+                VStack(spacing: 2) {
+                    HStack(spacing: 8) {
+                        Text("Version")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundStyle(.secondary)
+                        Text(AppInfo.version)
+                            .font(.system(size: 14, weight: .medium, design: .monospaced))
+                            .foregroundStyle(.primary)
+                    }
+
+                    Text("© \(AppInfo.copyrightYear) Austin Smith")
+                        .font(.system(size: 12))
+                        .foregroundStyle(.tertiary)
+                        .padding(.top, 12)
+                }
+                .accessibilityElement(children: .combine)
+
+                VStack(spacing: 8) {
+                    Divider()
+                        .padding(.horizontal, 24)
+
+                    Link("GitHub", destination: AppInfo.githubURL)
+                        .buttonStyle(.bordered)
+                        .controlSize(.regular)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 32)
+            .padding(.bottom, 40)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
         .navigationTitle("About")
         .navigationBarTitleDisplayMode(.inline)
-#else
-        aboutContent
-            .padding(.horizontal, 28)
-            .padding(.vertical, 24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(.regularMaterial)
-#endif
-    }
-
-    private var aboutContent: some View {
-        VStack(spacing: AboutViewMetrics.contentSpacing) {
-            Image("AppIconPreviewDefault")
-                .resizable()
-                .aspectRatio(contentMode: .fit)
-                .frame(
-                    width: AboutViewMetrics.iconSize,
-                    height: AboutViewMetrics.iconSize
-                )
-                .clipShape(
-                    .rect(
-                        cornerRadius: AboutViewMetrics.iconCornerRadius,
-                        style: .continuous
-                    )
-                )
-                .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
-                .accessibilityHidden(true)
-
-            VStack(spacing: 4) {
-                Text("Computer Solitaire")
-                    .font(AboutViewMetrics.titleFont)
-                    .foregroundStyle(.primary)
-
-                Text(tagline)
-                    .font(AboutViewMetrics.taglineFont)
-                    .foregroundStyle(.secondary)
-            }
-            .multilineTextAlignment(.center)
-            .fixedSize(horizontal: false, vertical: true)
-
-            Text("Computer Solitaire is a low-frills, ad-free solitaire game for your computer. Includes Klondike, FreeCell, and other things you enjoy.")
-                .font(AboutViewMetrics.descriptionFont)
-                .foregroundStyle(.primary)
-                .multilineTextAlignment(.center)
-                .fixedSize(horizontal: false, vertical: true)
-#if os(iOS)
-                .padding(.horizontal, 8)
-#endif
-
-            VStack(spacing: 2) {
-                HStack(spacing: 8) {
-                    Text("Version")
-                        .foregroundStyle(.secondary)
-                    Text(AppInfo.version)
-                        .fontDesign(.monospaced)
-                        .foregroundStyle(.primary)
-                }
-                .font(AboutViewMetrics.versionFont)
-
-                Text("© \(AppInfo.copyrightYear) Austin Smith")
-                    .font(AboutViewMetrics.copyrightFont)
-                    .foregroundStyle(.tertiary)
-                    .padding(.top, 12)
-            }
-            .accessibilityElement(children: .combine)
-
-            VStack(spacing: 8) {
-                Divider()
-                    .padding(.horizontal, 24)
-
-                Link("GitHub", destination: AppInfo.githubURL)
-                    .buttonStyle(.bordered)
-                    .controlSize(.regular)
-            }
-        }
-    }
-
-    private var tagline: String {
-        "Fully native solitaire game for your computer."
     }
 }
 
 #Preview("About") {
-#if os(iOS)
     NavigationStack {
         AboutView()
     }
+}
 #else
+struct AboutView: View {
+    @Environment(\.openURL) private var openURL
+
+    private var appVersion: String {
+        Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
+    }
+
+    private var copyrightYear: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy"
+        return formatter.string(from: Date())
+    }
+
+    var body: some View {
+        VStack(spacing: 12) {
+            VStack(spacing: 8) {
+                Image(nsImage: NSApp.applicationIconImage)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 100, height: 100)
+                    .clipShape(RoundedRectangle(cornerRadius: 22, style: .continuous))
+                    .shadow(color: .black.opacity(0.15), radius: 12, x: 0, y: 6)
+
+                VStack(spacing: 3) {
+                    Text("Computer Solitaire")
+                        .font(.system(size: 22, weight: .bold, design: .monospaced))
+                        .foregroundStyle(.primary)
+
+                    Text("Solitaire game for your computer")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text("Computer Solitaire is a low-frills, ad-free solitaire game for your computer. Includes Klondike, FreeCell, and other things you enjoy.")
+                .font(.system(size: 11))
+                .foregroundStyle(.primary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 2) {
+                HStack(spacing: 8) {
+                    Text("Version")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(appVersion)
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(.primary)
+                }
+
+                Text("© \(copyrightYear) Austin Smith")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.tertiary)
+                    .padding(.top, 8)
+            }
+
+            VStack(spacing: 6) {
+                Divider()
+                    .padding(.horizontal, 24)
+
+                Button {
+                    guard let url = URL(string: "https://github.com/austin-smith/ComputerSolitaire") else { return }
+                    openURL(url)
+                } label: {
+                    Text("GitHub")
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.regular)
+            }
+        }
+        .padding(.horizontal, 28)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(.regularMaterial, in: RoundedRectangle(cornerRadius: 0))
+    }
+}
+
+#Preview("About Us") {
     AboutView()
         .frame(width: 320, height: 380)
-#endif
 }
+#endif

--- a/ComputerSolitaire/Views/SettingsView.swift
+++ b/ComputerSolitaire/Views/SettingsView.swift
@@ -88,6 +88,10 @@ struct SettingsView: View {
 #endif
 
             helpSection
+
+#if os(iOS)
+            aboutSection
+#endif
         }
         .navigationTitle("Settings")
 #if os(iOS)
@@ -286,6 +290,26 @@ struct SettingsView: View {
             Text("Help")
         }
     }
+
+#if os(iOS)
+    private var aboutSection: some View {
+        Section {
+            NavigationLink {
+                AboutView()
+            } label: {
+                HStack {
+                    Text("Computer Solitaire")
+                    Spacer()
+                    Text(AppInfo.version)
+                        .fontDesign(.monospaced)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        } header: {
+            Text("About")
+        }
+    }
+#endif
 
     // MARK: - Custom controls
 


### PR DESCRIPTION
## What changed

- add an About row to iOS Settings with the current app version
- make the existing About view work on both iOS and macOS
- show the app icon, tagline, description, version, copyright, divider, and GitHub link

## Why

iOS did not have a discoverable About page, while macOS already did. This gives both platforms a consistent place for app information.
