### PR TITLE
Bump version to 0.8.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ xcuserdata/
 ## Visual Studio Code
 .vscode
 
+# Local agent worktrees
+.claude/
+
 ## Build artifacts
 build/
 .build/

--- a/ComputerSolitaire.xcodeproj/project.pbxproj
+++ b/ComputerSolitaire.xcodeproj/project.pbxproj
@@ -316,7 +316,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 0.7.0;
+				MARKETING_VERSION = 0.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.ComputerSolitaire;
 				PRODUCT_NAME = "Computer Solitaire";
 				REGISTER_APP_GROUPS = YES;
@@ -368,7 +368,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 0.7.0;
+				MARKETING_VERSION = 0.8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crapshack.ComputerSolitaire;
 				PRODUCT_NAME = "Computer Solitaire";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
## What Changed

- Bump the marketing version from 0.7.0 to 0.8.0.
- Ignore the local `.claude/` agent worktree directory.
