### PR TITLE
Reorganize toolbars

### DIFF
--- a/ComputerSolitaire/Feedback/HapticManager.swift
+++ b/ComputerSolitaire/Feedback/HapticManager.swift
@@ -14,6 +14,8 @@ final class HapticManager {
         case invalidDrop
         case undoMove
         case settingsSelection
+        case autoFinishStart
+        case gameWon
     }
 
     private(set) var trigger: UInt64 = 0
@@ -55,6 +57,10 @@ private extension HapticManager.Event {
             return .error
         case .settingsSelection:
             return .impact
+        case .autoFinishStart:
+            return .impact
+        case .gameWon:
+            return .success
         }
     }
 }

--- a/ComputerSolitaire/Views/Shared/ContentView.swift
+++ b/ComputerSolitaire/Views/Shared/ContentView.swift
@@ -231,27 +231,59 @@ struct ContentView: View {
             view
             .toolbar {
 #if os(iOS)
-                ToolbarItemGroup(placement: .bottomBar) {
+                ToolbarItem(placement: .bottomBar) {
                     Menu {
-                        Button("New Game", systemImage: "plus") {
-                            startNewGameFromUI()
-                        }
-                        Button("Redeal", systemImage: "arrow.clockwise") {
-                            redealFromUI()
-                        }
-                        .disabled(!viewModel.canRedeal)
-                        Button("Auto Finish", systemImage: "bolt") {
-                            startAutoFinish()
-                        }
-                        .disabled(isAutoFinishDisabled)
-                        if isHintButtonVisible {
-                            Button("Hint", systemImage: "lightbulb") {
-                                triggerHint()
+                        Section {
+                            Button("New Game", systemImage: "plus") {
+                                startNewGameFromUI()
                             }
-                            .disabled(isHintDisabled)
+                            Button("Redeal", systemImage: "arrow.clockwise") {
+                                redealFromUI()
+                            }
+                            .disabled(!viewModel.canRedeal)
+                        }
+                        Section {
+                            Button("Statistics", systemImage: "chart.bar") {
+                                isShowingStats = true
+                            }
+                            Button("Rules & Scoring", systemImage: "book") {
+                                presentRulesAndScoring(initialSection: .rules)
+                            }
+                        }
+                        Section {
+                            Button("Settings", systemImage: "gearshape") {
+                                isShowingSettings = true
+                            }
                         }
                     } label: {
-                        Label("Game", systemImage: "ellipsis.circle")
+                        Label("More", systemImage: "ellipsis")
+                    }
+                }
+                ToolbarSpacer(.flexible, placement: .bottomBar)
+                if viewModel.isAutoFinishAvailable {
+                    ToolbarItem(placement: .bottomBar) {
+                        Button {
+                            startAutoFinish()
+                        } label: {
+                            // The bottom bar renders Labels icon-only.
+                            HStack(spacing: 5) {
+                                Image(systemName: "bolt")
+                                Text("Auto")
+                            }
+                        }
+                        .accessibilityLabel("Auto Finish")
+                        .disabled(isAutoFinishDisabled)
+                    }
+                    ToolbarSpacer(.fixed, placement: .bottomBar)
+                }
+                ToolbarItemGroup(placement: .bottomBar) {
+                    if isHintButtonVisible {
+                        Button {
+                            triggerHint()
+                        } label: {
+                            Label("Hint", systemImage: "lightbulb")
+                        }
+                        .disabled(isHintDisabled)
                     }
                     Button {
                         stopAutoFinish()
@@ -260,39 +292,26 @@ struct ContentView: View {
                         Label("Undo", systemImage: "arrow.uturn.backward")
                     }
                     .disabled(isUndoDisabled)
-                    Spacer(minLength: 0)
-                    Button {
-                        isShowingStats = true
-                    } label: {
-                        Label("Statistics", systemImage: "chart.bar")
-                    }
-                    Button {
-                        isShowingSettings = true
-                    } label: {
-                        Label("Settings", systemImage: "gearshape")
-                    }
                 }
 #endif
 #if os(macOS)
                 ToolbarSpacer(.flexible)
-                ToolbarItemGroup(placement: .primaryAction) {
-                    Button {
-                        startNewGameFromUI()
-                    } label: {
-                        Label("New Game", systemImage: "plus")
+                if viewModel.isAutoFinishAvailable {
+                    ToolbarItem(placement: .primaryAction) {
+                        Button {
+                            startAutoFinish()
+                        } label: {
+                            HStack(spacing: 5) {
+                                Image(systemName: "bolt")
+                                Text("Auto")
+                            }
+                        }
+                        .accessibilityLabel("Auto Finish")
+                        .help("Auto Finish")
+                        .disabled(isAutoFinishDisabled)
                     }
-                    .labelStyle(.iconOnly)
-                    .help("New Game")
-                    Button {
-                        redealFromUI()
-                    } label: {
-                        Label("Redeal", systemImage: "arrow.clockwise")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help("Redeal")
-                    .disabled(!viewModel.canRedeal)
+                    ToolbarSpacer(.fixed)
                 }
-                ToolbarSpacer(.fixed)
                 ToolbarItemGroup(placement: .primaryAction) {
                     Button {
                         stopAutoFinish()
@@ -303,14 +322,6 @@ struct ContentView: View {
                     .labelStyle(.iconOnly)
                     .help("Undo")
                     .disabled(isUndoDisabled)
-                    Button {
-                        startAutoFinish()
-                    } label: {
-                        Label("Auto Finish", systemImage: "bolt")
-                    }
-                    .labelStyle(.iconOnly)
-                    .help("Auto Finish")
-                    .disabled(isAutoFinishDisabled)
                     if isHintButtonVisible {
                         Button {
                             triggerHint()
@@ -321,6 +332,25 @@ struct ContentView: View {
                         .help("Hint")
                         .disabled(isHintDisabled)
                     }
+                }
+                ToolbarSpacer(.fixed)
+                ToolbarItem(placement: .primaryAction) {
+                    Menu {
+                        Button("New Game", systemImage: "plus") {
+                            startNewGameFromUI()
+                        }
+                        Button("Redeal", systemImage: "arrow.clockwise") {
+                            redealFromUI()
+                        }
+                        .disabled(!viewModel.canRedeal)
+                    } label: {
+                        Label("New Game", systemImage: "plus")
+                    }
+                    .labelStyle(.iconOnly)
+                    .help("New Game or Redeal")
+                }
+                ToolbarSpacer(.fixed)
+                ToolbarItemGroup(placement: .primaryAction) {
                     Button {
                         isShowingStats = true
                     } label: {
@@ -683,6 +713,7 @@ struct ContentView: View {
         .onChange(of: viewModel.isWin) { _, isWin in
             guard !isHydratingGame else { return }
             if isWin {
+                HapticManager.shared.play(.gameWon)
                 winCelebration.beginIfNeededForWin(
                     launchPiles: winCascadeLaunchPiles,
                     launchTargets: winCascadeLaunchTargets,
@@ -1040,6 +1071,7 @@ struct ContentView: View {
 
     private func startAutoFinish() {
         guard !isAutoFinishDisabled else { return }
+        HapticManager.shared.play(.autoFinishStart)
         isAutoFinishing = true
         queueAutoFinishStepIfPossible()
     }


### PR DESCRIPTION
## What Changed

**iOS bottom bar**
- The More menu (`ellipsis`) now holds everything non-gameplay, in sections: New Game/Redeal, Statistics/Rules & Scoring, Settings
- Hint and Undo are top-level buttons at the trailing edge
- Auto Finish is a contextual "Auto" pill (bolt + text) that exists only while `isAutoFinishAvailable`; Statistics and Settings no longer occupy top-level slots

**macOS toolbar**
- Same contextual "Auto" button, appearing after the flexible spacer so no other item shifts
- Undo and Hint grouped as the persistent game pod
- New Game and Redeal collapse into a single `+` menu
- Statistics and Settings pair at the trailing edge; the menu bar (Game ▸ Statistics, Game ▸ Auto Finish) remains the always-visible path

**Haptics**
- New events: `autoFinishStart` (impact, fired on starting auto finish) and `gameWon` (success, fired on every live win — manual, auto finish, and Golf hole clears; suppressed during game hydration)

## Why

The previous bars mixed three kinds of actions — in-game moves, game flow, and app chrome — in one flat row with no hierarchy, and buried time-sensitive actions (Hint, Auto Finish) behind a menu on iOS while rarely-used ones (Statistics, Settings) held top-level slots. Placement now follows frequency of use, and Auto Finish's presence itself signals the moment a win becomes mechanical instead of idling as a disabled button. Wins previously had no haptic feedback at all.

## Validation

- Full macOS test suite passes (`xcodebuild ... -destination 'platform=macOS' test` — all suites green)
- Debug builds succeed for iOS Simulator and macOS
- Exercised in the iOS simulator: menu sections, contextual Auto pill appearance, and final layout verified visually

## UI Changes

- iOS bottom bar: `⋯` menu · (Auto when finishable) · Hint · Undo
- macOS toolbar: (Auto when finishable) · Undo | Hint · `+` menu · Stats | Settings