### PR TITLE
Polish game presentation and rules verbiage

### DIFF
--- a/ComputerSolitaire/Game/Shared/GameMode.swift
+++ b/ComputerSolitaire/Game/Shared/GameMode.swift
@@ -14,12 +14,12 @@ enum GameMode: String, CaseIterable, Codable {
     case spiderTwoSuits = "spider.suits2"
     case spiderFourSuits = "spider.suits4"
     case freecell
-    case tripeaks
     case pyramid
+    case tripeaks
     case golf
-    case fortyThieves = "fortythieves"
     case yukon
     case scorpion
+    case fortyThieves = "fortythieves"
     case canfield
 
     var variant: GameVariant {

--- a/ComputerSolitaire/Game/Shared/GameVariant.swift
+++ b/ComputerSolitaire/Game/Shared/GameVariant.swift
@@ -7,12 +7,12 @@ enum GameVariant: String, CaseIterable, Codable {
     case klondike
     case spider
     case freecell
-    case tripeaks
     case pyramid
+    case tripeaks
     case golf
-    case fortyThieves = "fortythieves"
     case yukon
     case scorpion
+    case fortyThieves = "fortythieves"
     case canfield
 
     var title: String {

--- a/ComputerSolitaire/GameMenuCommands.swift
+++ b/ComputerSolitaire/GameMenuCommands.swift
@@ -120,17 +120,11 @@ struct GameMenuCommands: Commands {
         }
     }
 
-    /// ⌘1 through ⌘9 select the first nine variants and ⌘0 the tenth; any
-    /// beyond that get no shortcut — there are only ten digit keys.
+    /// ⌘0 through ⌘9 select the first ten variants in presentation order;
+    /// any beyond that get no shortcut — there are only ten digit keys.
     private static func variantShortcut(at index: Int) -> KeyEquivalent? {
-        let ordinal = index + 1
-        if ordinal <= 9 {
-            return KeyEquivalent(Character("\(ordinal)"))
-        }
-        if ordinal == 10 {
-            return "0"
-        }
-        return nil
+        guard (0...9).contains(index) else { return nil }
+        return KeyEquivalent(Character("\(index)"))
     }
 }
 #endif

--- a/ComputerSolitaire/Views/AboutView.swift
+++ b/ComputerSolitaire/Views/AboutView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 
 #if os(iOS)
 enum AppInfo {
-    static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+    static let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
     static let copyrightYear = String(Calendar.current.component(.year, from: Date()))
     static let githubURL = URL(string: "https://github.com/austin-smith/ComputerSolitaire")
 }
@@ -32,7 +32,7 @@ struct AboutView: View {
 
                 Text(
                     "Computer Solitaire is a low-frills, ad-free solitaire game for your computer. "
-                        + "Includes Klondike, FreeCell, and other things you enjoy."
+                        + "Includes Klondike, Spider, FreeCell, and other things you enjoy."
                 )
                     .font(.system(size: 14))
                     .foregroundStyle(.primary)
@@ -88,7 +88,7 @@ struct AboutView: View {
     @Environment(\.openURL) private var openURL
 
     private var appVersion: String {
-        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "—"
+        Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String ?? "Unknown"
     }
 
     private var copyrightYear: String {
@@ -121,7 +121,7 @@ struct AboutView: View {
 
             Text(
                 "Computer Solitaire is a low-frills, ad-free solitaire game for your computer. "
-                    + "Includes Klondike, FreeCell, and other things you enjoy."
+                    + "Includes Klondike, Spider, FreeCell, and other things you enjoy."
             )
                 .font(.system(size: 11))
                 .foregroundStyle(.primary)

--- a/ComputerSolitaire/Views/RulesAndScoringView.swift
+++ b/ComputerSolitaire/Views/RulesAndScoringView.swift
@@ -35,8 +35,8 @@ struct RulesAndScoringView: View {
         TermRow(term: "Tableau", definition: "The seven play piles where you build down in alternating colors."),
         TermRow(term: "Foundations", definition: "Four suit piles built up from Ace to King."),
         TermRow(term: "Stock", definition: "The face-down draw pile."),
-        TermRow(term: "Waste", definition: "Face-up cards drawn from the stock; only the top card is playable."),
-        TermRow(term: "Draw mode", definition: "How many cards are drawn from stock each time: 1-card or 3-card.")
+        TermRow(term: "Waste", definition: "Face-up cards drawn from the stock — only the top card is playable."),
+        TermRow(term: "Draw mode", definition: "How many cards you draw from the stock at a time: 1-card or 3-card.")
     ]
 
     private var gameVariant: GameVariant {
@@ -193,7 +193,7 @@ struct RulesAndScoringView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 } else {
-                    Text("On win, a time bonus is added.")
+                    Text("When you win, a time bonus is added.")
                         .font(.caption)
                         .foregroundStyle(.secondary)
                     Text(
@@ -235,10 +235,10 @@ struct RulesAndScoringView: View {
             return [
                 TermRow(term: "Cascade", definition: "One of eight tableau columns where all cards are face up."),
                 TermRow(term: "Free Cell", definition: "A temporary single-card holding slot (four total)."),
-                TermRow(term: "Foundation", definition: "Four suit piles built from Ace to King."),
+                TermRow(term: "Foundations", definition: "Four suit piles built up from Ace to King."),
                 TermRow(
                     term: "Supermove",
-                    definition: "A multi-card move enabled by available free cells and empty cascades."
+                    definition: "A multi-card move made possible by open free cells and empty cascades."
                 )
             ]
         case .yukon:
@@ -255,24 +255,24 @@ struct RulesAndScoringView: View {
                 TermRow(term: "Tableau", definition: "The ten play piles where you build down, regardless of suit."),
                 TermRow(
                     term: "Run",
-                    definition: "Face-up cards of one suit in descending order; only runs move together."
+                    definition: "Face-up cards of one suit in descending order — only runs move together."
                 ),
                 TermRow(
                     term: "Completed run",
-                    definition: "A full King-to-Ace run of one suit. It leaves the tableau automatically; eight complete the game."
+                    definition: "A full King-to-Ace run of one suit. It leaves the tableau automatically — eight complete the game."
                 ),
                 TermRow(term: "Stock", definition: "The face-down pile that deals one card onto every tableau pile at once."),
-                TermRow(term: "Suits", definition: "The difficulty: 1, 2, or 4 suits composing the two decks (104 cards).")
+                TermRow(term: "Suits", definition: "The difficulty setting: the two decks are made of 1, 2, or 4 suits, always 104 cards.")
             ]
         case .pyramid:
             return [
                 TermRow(
                     term: "Pyramid",
-                    definition: "Twenty-eight face-up cards in seven overlapping rows; a card is exposed once both cards covering it are gone."
+                    definition: "Twenty-eight face-up cards in seven overlapping rows — a card is exposed once both cards covering it are gone."
                 ),
                 TermRow(term: "Stock", definition: "The face-down draw pile."),
-                TermRow(term: "Waste", definition: "Face-up cards drawn from the stock; only the top card is playable."),
-                TermRow(term: "Discard", definition: "Where removed pairs and Kings go; cards there are out of play."),
+                TermRow(term: "Waste", definition: "Face-up cards drawn from the stock — only the top card is playable."),
+                TermRow(term: "Discard", definition: "Where removed pairs and Kings go — cards there are out of play."),
                 TermRow(
                     term: "Recycle",
                     definition: "Turning the waste back into the stock. Pyramid allows two recycles (three passes)."
@@ -282,28 +282,28 @@ struct RulesAndScoringView: View {
             return [
                 TermRow(
                     term: "Peaks",
-                    definition: "Twenty-eight cards in three overlapping peaks; a card is uncovered once both cards covering it are gone, and flips face up."
+                    definition: "Twenty-eight cards in three overlapping peaks — a card is uncovered once both cards covering it are gone, and flips face up."
                 ),
-                TermRow(term: "Stock", definition: "The face-down draw pile. One pass only — there are no recycles."),
+                TermRow(term: "Stock", definition: "The face-down draw pile. You get one pass through it — no recycles."),
                 TermRow(
                     term: "Waste",
-                    definition: "The growing face-up pile; play any uncovered card one rank above or below its top."
+                    definition: "The growing face-up pile — play any uncovered card one rank above or below its top."
                 ),
                 TermRow(
                     term: "Chain",
-                    definition: "Consecutive discards without flipping the stock; each discard in a chain is worth one more point than the last."
+                    definition: "Consecutive discards without flipping the stock — each discard in a chain is worth one more point than the last."
                 )
             ]
         case .golf:
             return [
                 TermRow(
                     term: "Columns",
-                    definition: "Seven face-up piles of five cards; only each column's exposed card may play."
+                    definition: "Seven face-up piles of five cards — only each column's exposed card may play."
                 ),
-                TermRow(term: "Stock", definition: "The face-down draw pile. One pass only — there are no recycles."),
+                TermRow(term: "Stock", definition: "The face-down draw pile. You get one pass through it — no recycles."),
                 TermRow(
                     term: "Waste",
-                    definition: "The growing face-up pile; play any exposed card one rank above or below its top."
+                    definition: "The growing face-up pile — play any exposed card one rank above or below its top."
                 ),
                 TermRow(term: "Hole", definition: "One deal. Nine holes make a match."),
                 TermRow(
@@ -315,38 +315,38 @@ struct RulesAndScoringView: View {
             return [
                 TermRow(
                     term: "Tableau",
-                    definition: "Ten columns of four face-up cards; build down by suit, one card at a time."
+                    definition: "Ten columns of four face-up cards — build down by suit, one card at a time."
                 ),
                 TermRow(
                     term: "Foundations",
-                    definition: "Eight suit piles built up from Ace to King — two per suit; cards placed here never return."
+                    definition: "Eight suit piles built up from Ace to King, two per suit. Cards placed here never return to play."
                 ),
-                TermRow(term: "Stock", definition: "The face-down draw pile. One pass only — there are no recycles."),
+                TermRow(term: "Stock", definition: "The face-down draw pile. You get one pass through it — no recycles."),
                 TermRow(
                     term: "Waste",
-                    definition: "Face-up cards drawn from the stock; only the top card is playable."
+                    definition: "Face-up cards drawn from the stock — only the top card is playable."
                 )
             ]
         case .canfield:
             return [
                 TermRow(
                     term: "Reserve",
-                    definition: "Thirteen face-down cards with the top one face up and playable; it must fill any empty tableau pile at once."
+                    definition: "Thirteen face-down cards with the top one face up and playable. Its top card automatically fills any empty tableau pile."
                 ),
                 TermRow(
                     term: "Base card",
-                    definition: "The card dealt to the first foundation; its rank starts all four foundations."
+                    definition: "The card dealt to the first foundation — its rank starts all four foundations."
                 ),
                 TermRow(
                     term: "Tableau",
-                    definition: "Four piles built down in alternating colors, wrapping from Ace to King; a pile moves only in its entirety."
+                    definition: "Four piles built down in alternating colors, wrapping from Ace to King. Piles move only as a whole."
                 ),
                 TermRow(
                     term: "Foundations",
-                    definition: "Four suit piles built up from the base rank, wrapping from King to Ace; cards placed here never return."
+                    definition: "Four suit piles built up from the base rank, wrapping from King to Ace. Cards placed here never return to play."
                 ),
-                TermRow(term: "Stock", definition: "The face-down draw pile; three cards turn at a time, with unlimited redeals."),
-                TermRow(term: "Waste", definition: "Face-up cards drawn from the stock; only the top card is playable.")
+                TermRow(term: "Stock", definition: "The face-down draw pile. Three cards turn over at a time, with unlimited redeals."),
+                TermRow(term: "Waste", definition: "Face-up cards drawn from the stock — only the top card is playable.")
             ]
         case .scorpion:
             return [
@@ -357,11 +357,11 @@ struct RulesAndScoringView: View {
                 ),
                 TermRow(
                     term: "Completed run",
-                    definition: "A full King-to-Ace run of one suit. It leaves the tableau automatically; four complete the game."
+                    definition: "A full King-to-Ace run of one suit. It leaves the tableau automatically — four complete the game."
                 ),
                 TermRow(
                     term: "Stock",
-                    definition: "Three face-down cards, dealt face up onto the first three piles at any time — once."
+                    definition: "Three face-down cards, dealt face up onto the first three piles at any time — but only once."
                 )
             ]
         }
@@ -371,98 +371,99 @@ struct RulesAndScoringView: View {
         switch gameVariant {
         case .klondike:
             return [
-                "Build tableau piles down by alternating colors.",
-                "Move Aces to foundations first, then build each suit up to King.",
+                "Deal seven tableau piles: the first holds one card, the second two, and so on to seven, with only each pile's top card face up. The rest of the deck forms the stock.",
+                "Build tableau piles down in alternating colors.",
+                "Move Aces to the foundations as they appear, then build each suit up to King.",
                 "Only Kings can fill an empty tableau pile.",
                 "In 1-card draw, flip one stock card at a time. In 3-card draw, flip three.",
-                "When stock is empty, recycle waste to stock and continue.",
-                "You win by moving all 52 cards to foundations."
+                "When the stock is empty, recycle the waste back into it and keep going.",
+                "You win by moving all 52 cards to the foundations."
             ]
         case .freecell:
             return [
                 "Deal all 52 cards face up into eight cascades (four with 7 cards, four with 6 cards).",
-                "Build cascades down by alternating colors.",
+                "Build cascades down in alternating colors.",
                 "Use the four free cells as temporary storage for one card each.",
-                "Build foundations by suit from Ace to King.",
-                "Any card may move to an empty cascade.",
-                "You win by moving all 52 cards to foundations."
+                "Build the foundations up by suit from Ace to King.",
+                "Any card can move to an empty cascade.",
+                "You win by moving all 52 cards to the foundations."
             ]
         case .yukon:
             return [
-                "Deal seven tableau piles: the first holds one face-up card; each pile after adds one more face-down card beneath five face-up cards. All 52 cards are dealt — there is no stock.",
+                "Deal seven tableau piles: the first holds one face-up card, and each pile after adds one more face-down card beneath five face-up cards. All 52 cards are dealt — there is no stock.",
                 "Move any face-up card along with all cards on top of it, even if they are not in sequence.",
                 "The moving group's bottom card must land on a card of the opposite color, one rank higher.",
-                "Build foundations by suit from Ace to King.",
+                "Build the foundations up by suit from Ace to King.",
                 "Only Kings (with any cards stacked on them) can fill an empty pile.",
                 "Face-down cards turn face up when they become the top of a pile.",
-                "You win by moving all 52 cards to foundations."
+                "You win by moving all 52 cards to the foundations."
             ]
         case .spider:
             return [
-                "Two decks (104 cards) are dealt into ten tableau piles: six cards in each of the first four, five in the rest, with only the top card face up. The remaining 50 cards form the stock.",
+                "Deal two decks (104 cards) into ten tableau piles: six cards in each of the first four piles and five in the rest, with only the top card face up. The remaining 50 cards form the stock.",
                 "A card can move onto any card one rank higher, regardless of suit. Nothing can be placed on an Ace.",
                 "Several cards move together only as a face-up run of one suit in descending order.",
                 "Any card or movable run can fill an empty pile.",
-                "Tapping the stock deals one face-up card onto every pile. Dealing is not allowed while any pile is empty.",
+                "Tap the stock to deal one face-up card onto every pile. You cannot deal while any pile is empty.",
                 "A completed King-to-Ace run of one suit is removed from the tableau automatically.",
                 "Face-down cards turn face up when they become the top of a pile.",
                 "You win by completing all eight runs."
             ]
         case .pyramid:
             return [
-                "Deal 28 cards face up into a seven-row pyramid; the remaining 24 form the stock.",
-                "Remove exposed pairs whose ranks total 13: Ace is 1, Jack 11, Queen 12.",
-                "Kings count 13 alone and are removed singly.",
-                "A card is exposed once neither card covering it remains. A card whose only cover is its matching partner may be removed together with it.",
-                "Tap the stock to draw one card to the waste; the top waste card can pair with exposed pyramid cards.",
+                "Deal 28 cards face up into a seven-row pyramid. The remaining 24 cards form the stock.",
+                "Remove pairs of exposed cards whose ranks total 13. Ace counts 1, Jack 11, and Queen 12.",
+                "Kings count 13 on their own and are removed singly.",
+                "A card is exposed once neither card covering it remains. A card whose only cover is its matching partner can be removed together with it.",
+                "Tap the stock to draw one card to the waste — the top waste card can pair with exposed pyramid cards.",
                 "When the stock runs out, recycle the waste back into it — at most twice.",
-                "You win by removing all 28 pyramid cards; stock and waste may keep cards."
+                "You win by removing all 28 pyramid cards. The stock and waste do not need to be empty."
             ]
         case .tripeaks:
             return [
-                "Deal 28 cards into three overlapping peaks — three face-down rows topped by a face-up base row of ten. One card starts the waste; the remaining 23 form the stock.",
+                "Deal 28 cards into three overlapping peaks, with three face-down rows under a face-up base row of ten. One card starts the waste, and the remaining 23 form the stock.",
                 "Play any uncovered card that is one rank above or below the top waste card, regardless of suit. It becomes the new target.",
                 "Ranks wrap around: a King plays on an Ace and an Ace plays on a King or a Two.",
                 "A face-down card flips face up once both cards covering it are removed.",
-                "Tap the stock to flip one card onto the waste. The stock allows a single pass — there are no recycles.",
-                "You win by clearing all 28 peak cards; stock and waste may keep cards."
+                "Tap the stock to flip one card onto the waste. You get one pass through the stock — no recycles.",
+                "You win by clearing all 28 peak cards. The stock and waste do not need to be empty."
             ]
         case .golf:
             return [
-                "Deal 35 cards face up into seven columns of five. One card starts the waste; the remaining 16 form the stock.",
+                "Deal 35 cards face up into seven columns of five. One card starts the waste, and the remaining 16 form the stock.",
                 "Play any exposed column card that is one rank above or below the top waste card, regardless of suit. It becomes the new target.",
                 "Ranks never wrap: an Ace connects only to a Two, and a King only to a Queen.",
-                "Nothing plays on a King — once a King tops the waste, flip the stock to bury it.",
-                "Tap the stock to flip one card onto the waste. The stock allows a single pass — there are no recycles.",
+                "Nothing plays on a King — once one tops the waste, flip the stock to bury it.",
+                "Tap the stock to flip one card onto the waste. You get one pass through the stock — no recycles.",
                 "The hole ends when you clear all 35 column cards, or when the stock is spent and nothing plays.",
-                "A match is nine holes; the lowest total wins. Switching games keeps the match — it resumes with your Golf session."
+                "A match is nine holes, and the lowest total wins. Switching games keeps the match — it resumes when you return to Golf."
             ]
         case .fortyThieves:
             return [
-                "Two decks (104 cards) are dealt into ten tableau columns of four face-up cards. The remaining 64 cards form the stock.",
-                "Build tableau columns down by suit, one rank at a time. Only the exposed top card of a column may move — sequences never move together.",
-                "Any single available card — an exposed tableau card or the top waste card — may fill an empty column.",
+                "Deal two decks (104 cards) into ten tableau columns of four face-up cards. The remaining 64 cards form the stock.",
+                "Build tableau columns down by suit, one rank at a time. Only the top card of a column can move, so sequences never move together.",
+                "Any single available card — an exposed tableau card or the top waste card — can fill an empty column.",
                 "Build the eight foundations up by suit from Ace to King, two per suit. Cards placed on a foundation never return to play.",
-                "Tap the stock to flip one card onto the waste, whenever you like. The stock allows a single pass — there are no recycles.",
-                "You win by moving all 104 cards to foundations. The game is lost when the stock is spent and no legal move remains."
+                "Tap the stock at any time to flip one card onto the waste. You get one pass through the stock — no recycles.",
+                "You win by moving all 104 cards to the foundations. The game is lost when the stock is spent and no legal move remains."
             ]
         case .canfield:
             return [
                 "Deal 13 cards into the reserve with the top card face up, one face-up base card onto the first foundation, and one face-up card onto each of four tableau piles. The remaining 34 cards form the stock.",
                 "All four foundations start at the base card's rank and build up by suit, wrapping from King to Ace. Cards placed on a foundation never return to play.",
-                "Build tableau piles down in alternating colors, wrapping from Ace to King. A pile moves onto another only in its entirety; the exposed top card may play to a foundation.",
-                "An empty tableau pile is filled at once from the reserve. Once the reserve is empty, fill it with the top waste card whenever you choose.",
+                "Build tableau piles down in alternating colors, wrapping from Ace to King. Piles move onto each other only as a whole, though the exposed top card can always play to a foundation.",
+                "An empty tableau pile fills immediately from the reserve. Once the reserve is empty, fill empty piles with the top waste card whenever you choose.",
                 "The reserve's top card is always available to play on foundations or tableau piles.",
-                "Tap the stock to turn three cards onto the waste; when it runs out, tap again to turn the waste over and keep going — redeals are unlimited.",
-                "You win by moving all 52 cards to foundations."
+                "Tap the stock to turn three cards onto the waste. When it runs out, tap again to turn the waste back into a new stock — redeals are unlimited.",
+                "You win by moving all 52 cards to the foundations."
             ]
         case .scorpion:
             return [
-                "Deal 49 cards into seven tableau piles of seven. The first four piles hide their bottom three cards face down; the last three are fully face up. The remaining three cards form the stock.",
+                "Deal 49 cards into seven tableau piles of seven. The first four piles hide their bottom three cards face down, while the last three are fully face up. The remaining three cards form the stock.",
                 "A card can move only onto the card one rank higher of its own suit. Nothing can be placed on an Ace.",
                 "Move any face-up card along with all cards on top of it, even if they are not in sequence.",
                 "Only Kings (with any cards stacked on them) can fill an empty pile.",
-                "Tapping the stock deals its three cards face up, one onto each of the first three piles. Deal at any time — but only once.",
+                "Tap the stock to deal its three cards face up, one onto each of the first three piles. You can deal at any time — but only once.",
                 "A completed King-to-Ace run of one suit is removed from the tableau automatically.",
                 "Face-down cards turn face up when they become the top of a pile.",
                 "You win by completing all four runs."
@@ -476,7 +477,7 @@ struct RulesAndScoringView: View {
             return scoringRows
         case .freecell:
             return [
-                ScoringRow(move: "Move cards", points: 0, note: "FreeCell currently tracks time and completion."),
+                ScoringRow(move: "Move cards", points: 0, note: "FreeCell tracks time and completion."),
                 ScoringRow(
                     move: "Win time bonus",
                     points: Scoring.timedMaxBonusDrawThree,
@@ -554,7 +555,7 @@ struct RulesAndScoringView: View {
                 ScoringRow(
                     move: "Clear the board",
                     points: Scoring.delta(for: .golfBoardClear(remainingStockCount: 1)),
-                    note: "Per stock card left — scores below zero are the best results."
+                    note: "One point per stock card left — scores below zero are the best results."
                 )
             ]
         case .fortyThieves:

--- a/ComputerSolitaire/Views/StatisticsView.swift
+++ b/ComputerSolitaire/Views/StatisticsView.swift
@@ -86,6 +86,14 @@ private struct StatisticsOverviewView: View {
                 Text("Games")
             }
 
+#if os(iOS)
+            Section {
+                Button("Reset All Statistics", role: .destructive) {
+                    isShowingResetConfirmation = true
+                }
+            }
+#endif
+
             Text("Tracked since \(statsTrackedSinceLabel(aggregate))")
                 .font(.footnote)
                 .foregroundStyle(.tertiary)
@@ -98,12 +106,6 @@ private struct StatisticsOverviewView: View {
         .toolbar {
 #if os(macOS)
             ToolbarItem(placement: .automatic) {
-                Button("Reset Stats") {
-                    isShowingResetConfirmation = true
-                }
-            }
-#else
-            ToolbarItem(placement: .topBarLeading) {
                 Button("Reset Stats") {
                     isShowingResetConfirmation = true
                 }
@@ -287,6 +289,14 @@ private struct GameStatisticsDetailView: View {
                     Text("Performance")
                 }
 
+#if os(iOS)
+                Section {
+                    Button("Reset \(effectiveScopeTitle) Statistics", role: .destructive) {
+                        isShowingResetConfirmation = true
+                    }
+                }
+#endif
+
                 Text("Tracked since \(statsTrackedSinceLabel(stats))")
                     .font(.footnote)
                     .foregroundStyle(.tertiary)
@@ -300,12 +310,6 @@ private struct GameStatisticsDetailView: View {
         .toolbar {
 #if os(macOS)
             ToolbarItem(placement: .automatic) {
-                Button("Reset Stats") {
-                    isShowingResetConfirmation = true
-                }
-            }
-#else
-            ToolbarItem(placement: .topBarLeading) {
                 Button("Reset Stats") {
                     isShowingResetConfirmation = true
                 }

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
 ## Features
 
 - Fully native apps for iOS, iPadOS, and macOS
-- Multiple game variants: **Klondike** (both 1-card and 3-card draw), **Spider** (1, 2, or 4 suits), **FreeCell**, **TriPeaks**, **Pyramid**, **Golf**, **Forty Thieves**, **Yukon**, **Scorpion**, and **Canfield**
+- Multiple game variants: **Klondike** (both 1-card and 3-card draw), **Spider** (1, 2, or 4 suits), **FreeCell**, **Pyramid**, **TriPeaks**, **Golf**, **Yukon**, **Scorpion**, **Forty Thieves**, and **Canfield**
 - Automatic game persistence and resume
 - Customizable table appearance
 - Other things you enjoy
@@ -25,10 +25,10 @@ Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
 | **Klondike** | Classic Solitaire, with 1-card and 3-card draw modes | [Rules](docs/rules/klondike.md) |
 | **Spider** | Two decks, ten piles — build full suit runs from King to Ace, with 1/2/4-suit difficulty | [Rules](docs/rules/spider.md) |
 | **FreeCell** | Strategy-focused variant where every card is visible from the start | [Rules](docs/rules/freecell.md) |
-| **TriPeaks** | Chain uncovered cards one rank up or down to level three peaks | [Rules](docs/rules/tripeaks.md) |
 | **Pyramid** | Pair exposed cards totaling 13 to dismantle a 28-card pyramid | [Rules](docs/rules/pyramid.md) |
+| **TriPeaks** | Chain uncovered cards one rank up or down to level three peaks | [Rules](docs/rules/tripeaks.md) |
 | **Golf** | Play columns down to nothing, one rank up or down, scored like golf across a nine-hole match | [Rules](docs/rules/golf.md) |
-| **Forty Thieves** | Two decks, ten columns — build down by suit one card at a time, managing a single-pass stock | [Rules](docs/rules/fortythieves.md) |
 | **Yukon** | Klondike's wilder sibling — no stock, and any face-up card moves with everything stacked on it | [Rules](docs/rules/yukon.md) |
 | **Scorpion** | Spider's single-deck cousin — untangle suit runs in place with Yukon-style group moves | [Rules](docs/rules/scorpion.md) |
+| **Forty Thieves** | Two decks, ten columns — build down by suit one card at a time, managing a single-pass stock | [Rules](docs/rules/fortythieves.md) |
 | **Canfield** | The casino classic (Demon in Britain) — drain a 13-card reserve onto foundations that start at a dealt rank and wrap | [Rules](docs/rules/canfield.md) |

--- a/README.md
+++ b/README.md
@@ -23,12 +23,12 @@ Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
 | Variant | Description | Rules |
 |---------|-------------|-------|
 | **Klondike** | Classic Solitaire, with 1-card and 3-card draw modes | [Rules](docs/rules/klondike.md) |
-| **Spider** | Two decks, ten piles — build full suit runs from King to Ace, with 1/2/4-suit difficulty | [Rules](docs/rules/spider.md) |
-| **FreeCell** | Strategy-focused variant where every card is visible from the start | [Rules](docs/rules/freecell.md) |
-| **Pyramid** | Pair exposed cards totaling 13 to dismantle a 28-card pyramid | [Rules](docs/rules/pyramid.md) |
-| **TriPeaks** | Chain uncovered cards one rank up or down to level three peaks | [Rules](docs/rules/tripeaks.md) |
-| **Golf** | Play columns down to nothing, one rank up or down, scored like golf across a nine-hole match | [Rules](docs/rules/golf.md) |
-| **Yukon** | Klondike's wilder sibling — no stock, and any face-up card moves with everything stacked on it | [Rules](docs/rules/yukon.md) |
-| **Scorpion** | Spider's single-deck cousin — untangle suit runs in place with Yukon-style group moves | [Rules](docs/rules/scorpion.md) |
-| **Forty Thieves** | Two decks, ten columns — build down by suit one card at a time, managing a single-pass stock | [Rules](docs/rules/fortythieves.md) |
-| **Canfield** | The casino classic (Demon in Britain) — drain a 13-card reserve onto foundations that start at a dealt rank and wrap | [Rules](docs/rules/canfield.md) |
+| **Spider** | Build full King-to-Ace suit runs across ten piles, using two decks composed of 1, 2, or 4 suits | [Rules](docs/rules/spider.md) |
+| **FreeCell** | All 52 cards are dealt face up, with four free cells that each hold one card | [Rules](docs/rules/freecell.md) |
+| **Pyramid** | Remove pairs of exposed cards that total 13 to clear a 28-card pyramid | [Rules](docs/rules/pyramid.md) |
+| **TriPeaks** | Play uncovered cards one rank above or below the waste to clear three peaks | [Rules](docs/rules/tripeaks.md) |
+| **Golf** | Play column cards one rank above or below the waste, scored across a nine-hole match where lower is better | [Rules](docs/rules/golf.md) |
+| **Yukon** | Like Klondike, but with no stock — any face-up card moves along with every card stacked on it | [Rules](docs/rules/yukon.md) |
+| **Scorpion** | Build down by suit to complete four King-to-Ace runs in place, moving face-up cards with everything stacked on them | [Rules](docs/rules/scorpion.md) |
+| **Forty Thieves** | Build ten columns down by suit, one card at a time, using two decks and a single pass through the stock | [Rules](docs/rules/fortythieves.md) |
+| **Canfield** | Play a 13-card reserve onto foundations that start at a dealt base rank and wrap | [Rules](docs/rules/canfield.md) |

--- a/docs/rules/canfield.md
+++ b/docs/rules/canfield.md
@@ -1,17 +1,17 @@
 # Canfield Rules
 
-These rules describe Canfield as implemented in the app: the strict classic game — known as Demon in Britain, where it was first recorded — with a thirteen-card reserve, foundations that start at a dealt base rank and wrap, whole-pile tableau moves only, and a draw-three stock with unlimited redeals. The classic sources agree on the essentials; where modern software commonly relaxes them, the choices made here (and why) are called out below.
+These rules describe Canfield as implemented in the app: the strict classic game, known as Demon in Britain where it was first recorded, with a thirteen-card reserve, foundations that start at a dealt base rank and wrap, whole-pile tableau moves only, and a draw-three stock with unlimited redeals. The classic sources agree on the essentials. Where modern software commonly relaxes them, the choices made here (and why) are called out below.
 
 ## Objective
-Move all 52 cards onto the four foundations, building each up by suit from the base rank — the rank dealt to the first foundation — and turning the corner from King to Ace along the way.
+Move all 52 cards onto the four foundations, building each up by suit from the base rank (the rank dealt to the first foundation) and turning the corner from King to Ace along the way.
 
 ## Terminology
 - **Reserve:** A packet of thirteen cards, all face down except the exposed top card, which is always playable. British sources call it *the demon*. It must fill any empty tableau pile at once.
-- **Base card:** The card dealt face up to the first foundation; its rank is where all four foundations start.
+- **Base card:** The card dealt face up to the first foundation — its rank is where all four foundations start.
 - **Tableau:** Four piles built down in alternating colors, wrapping from Ace to King. A pile moves onto another only in its entirety.
 - **Foundations:** Four suit piles built up from the base rank, wrapping from King to Ace. Cards placed here never return to play.
 - **Stock:** The face-down draw pile (34 cards after the deal). Three cards turn at a time, with unlimited redeals.
-- **Waste:** Face-up cards turned from the stock; only the top card is playable.
+- **Waste:** Face-up cards turned from the stock — only the top card is playable.
 
 ## Setup
 - Use one standard 52-card deck (no jokers).
@@ -22,9 +22,9 @@ Move all 52 cards onto the four foundations, building each up by suit from the b
 
 ## Play
 ### Tableau
-- Build piles **down in alternating colors**, turning the corner from Ace to King — the K♠ plays onto the A♥ or A♦.
-- A pile moves onto another pile **only in its entirety**; a partial sequence never moves, however well packed. The exposed top card may always play to a foundation.
-- An **empty pile** fills at once from the reserve's top card — this is compulsory, and the app performs it automatically. Once the reserve is empty, fill a space with the **top waste card** whenever you choose; a space never fills from another tableau pile.
+- Build piles **down in alternating colors**, turning the corner from Ace to King (the K♠ plays onto the A♥ or A♦).
+- A pile moves onto another pile **only in its entirety** — a partial sequence never moves, however well packed. The exposed top card may always play to a foundation.
+- An **empty pile** fills at once from the reserve's top card — this is compulsory, and the app performs it automatically. Once the reserve is empty, fill a space with the **top waste card** whenever you choose. A space never fills from another tableau pile.
 
 ### Foundations
 - Each foundation starts with a card of the **base rank** and builds up in its suit, turning the corner from King to Ace, until it holds all thirteen cards.
@@ -34,9 +34,9 @@ Move all 52 cards onto the four foundations, building each up by suit from the b
 - The exposed top card is always available, to a foundation or onto a tableau pile. When it leaves, the next reserve card turns face up.
 
 ### The stock
-- Tap the stock to turn **three** cards face up onto the waste, order preserved; fewer than three remaining turn together.
+- Tap the stock to turn **three** cards face up onto the waste, order preserved. If fewer than three remain, they turn together.
 - Only the top waste card is playable, to the tableau or a foundation.
-- When the stock is spent, tap again to turn the waste over — unshuffled — as the new stock. **Redeals are unlimited.**
+- When the stock is spent, tap again to turn the waste over, unshuffled, as the new stock. **Redeals are unlimited.**
 
 ## Scoring
 - Waste to tableau: +5.
@@ -48,15 +48,15 @@ Move all 52 cards onto the four foundations, building each up by suit from the b
 - The score never goes below zero.
 
 ## Winning
-You win by moving all 52 cards to the foundations. The game is lost when no play exists from the reserve, tableau, or waste, and a full unchanged pass through the stock surfaces nothing playable. Canfield's reputation as a grind is earned — the casino legend has players buying the deck for $50 and winning $5 per card banked, against an average of five or six — but the deals themselves are more generous than the legend: solver studies find roughly two thirds winnable under these strict rules, with expert play converting about a third. Draining the reserve is the heart of the game.
+You win by moving all 52 cards to the foundations. The game is lost when no play exists from the reserve, tableau, or waste, and a full unchanged pass through the stock surfaces nothing playable. Canfield's reputation as a grind is earned. The casino legend has players buying the deck for $50 and winning $5 per card banked, against an average of five or six. The deals themselves are more generous than the legend: solver studies find roughly two thirds winnable under these strict rules, with expert play converting about a third. Draining the reserve is the heart of the game.
 
 ## Rule choices
-The classic sources are unusually consistent for a patience game; the choices here follow them against the relaxations common in software:
-- **Whole-pile movement only** — the classic rule in every printed source (Coops' *100 Games of Solitaire*: "sequences on tableau may be moved bodily, but not parts of sequences"; Morehead & Mott-Smith agree). Much modern software permits partial-sequence moves, a measurable easing (solver studies put it at roughly four points of winnability); the app keeps the by-the-book rule.
-- **Wrapping in both directions** — foundations turn King-to-Ace and tableau builds turn Ace-to-King. Both are definitional: with a random base rank, the cards just below it would otherwise be nearly unplayable.
-- **Compulsory reserve fill** — a space takes the reserve's top card at once, not at the player's option; choice enters only after the reserve is out, when the top waste card may fill a space (and nothing else may — not another tableau pile).
-- **Locked foundations** — a banked card never returns to play. No classic source permits "worrying back"; some apps offer it as a house option.
-- **Draw three with unlimited redeals** — universal across the classic sources. Deal-one variants exist (Rainbow) but are a different, far easier game. The in-app **Redeal** command replays the same deal from the start; it is a fresh attempt at the layout, not the stock recycle, which is unlimited and free.
+The classic sources are unusually consistent for a patience game. The choices here follow them against the relaxations common in software:
+- **Whole-pile movement only.** The classic rule in every printed source (Coops' *100 Games of Solitaire*: "sequences on tableau may be moved bodily, but not parts of sequences", and Morehead & Mott-Smith agree). Much modern software permits partial-sequence moves, a measurable easing (solver studies put it at roughly four points of winnability). The app keeps the by-the-book rule.
+- **Wrapping in both directions.** Foundations turn King-to-Ace and tableau builds turn Ace-to-King. Both are definitional: with a random base rank, the cards just below it would otherwise be nearly unplayable.
+- **Compulsory reserve fill.** A space takes the reserve's top card at once, not at the player's option. Choice enters only after the reserve is out, when the top waste card may fill a space (and nothing else may — not even another tableau pile).
+- **Locked foundations.** A banked card never returns to play. No classic source permits "worrying back", though some apps offer it as a house option.
+- **Draw three with unlimited redeals.** This is universal across the classic sources. Deal-one variants exist (Rainbow) but are a different, far easier game. The in-app **Redeal** command replays the same deal from the start — a fresh attempt at the layout, not the stock recycle, which is unlimited and free.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Canfield_(solitaire)

--- a/docs/rules/fortythieves.md
+++ b/docs/rules/fortythieves.md
@@ -1,15 +1,15 @@
 # Forty Thieves Rules
 
-These rules describe Forty Thieves as implemented in the app: the strict classic two-deck game — tableau built down by suit, single-card moves only, locked foundations, and a draw-one stock with a single pass. The published sources offer several relaxations; the choices made here (and why) are called out below.
+These rules describe Forty Thieves as implemented in the app: the strict classic two-deck game, with the tableau built down by suit, single-card moves only, locked foundations, and a draw-one stock limited to a single pass. The published sources offer several relaxations — the choices made here (and why) are called out below.
 
 ## Objective
 Move all 104 cards onto the eight foundations, building each up by suit from Ace to King. Because two decks are in play, every suit completes two foundations.
 
 ## Terminology
-- **Tableau:** Ten columns of four face-up cards; build down by suit, one card at a time.
-- **Foundations:** Eight suit piles built up from Ace to King — two per suit. Cards placed here never return to play.
-- **Stock:** The face-down draw pile (64 cards after the deal). One pass only — there are no recycles.
-- **Waste:** Face-up cards turned from the stock; only the top card is playable.
+- **Tableau:** Ten columns of four face-up cards — build down by suit, one card at a time.
+- **Foundations:** Eight suit piles built up from Ace to King, two per suit. Cards placed here never return to play.
+- **Stock:** The face-down draw pile (64 cards after the deal). You get one pass through it — no recycles.
+- **Waste:** Face-up cards turned from the stock — only the top card is playable.
 
 ## Setup
 - Use two standard 52-card decks shuffled together (104 cards, no jokers).
@@ -19,18 +19,18 @@ Move all 104 cards onto the eight foundations, building each up by suit from Ace
 
 ## Play
 ### Tableau
-- Build columns **down by suit**, one rank at a time — the 7♠ plays onto the 8♠ and nothing else.
+- Build columns **down by suit**, one rank at a time (the 7♠ plays onto the 8♠ and nothing else).
 - Only the **exposed top card** of a column may move. Sequences never move as a unit, however perfectly ordered.
-- Any single available card — an exposed tableau card or the top waste card — may fill an **empty column**.
+- Any single available card, either an exposed tableau card or the top waste card, may fill an **empty column**.
 
 ### Foundations
-- An available Ace starts any empty foundation; each foundation then builds up in its suit to the King.
+- An available Ace starts any empty foundation, and each foundation then builds up in its suit to the King.
 - A card placed on a foundation is **locked** — it never returns to the tableau.
 
 ### The stock
 - Tap the stock to turn **one** card face up onto the waste, whenever you like.
 - Only the top waste card is playable, to the tableau or a foundation.
-- The stock allows a **single pass** — once it is spent, the cards left in the waste stay in play only through the waste top.
+- You get a **single pass** through the stock. Once it is spent, the cards left in the waste stay in play only through the waste top.
 
 ## Scoring
 - Waste to tableau: +5.
@@ -40,15 +40,15 @@ Move all 104 cards onto the eight foundations, building each up by suit from Ace
 - The score never goes below zero.
 
 ## Winning
-You win by moving all 104 cards to the foundations. The game is lost when the stock is spent and no legal move remains. Strict Forty Thieves is a famously difficult game — expert play wins perhaps one deal in five — so most deals end as well-fought losses; empty columns and a carefully rationed stock are what winning deals have in common.
+You win by moving all 104 cards to the foundations. The game is lost when the stock is spent and no legal move remains. Strict Forty Thieves is a famously difficult game (expert play wins perhaps one deal in five), so most deals end as well-fought losses. Empty columns and a carefully rationed stock are what winning deals have in common.
 
 ## Rule choices
-The linked sources offer relaxations; this implementation uses:
-- **Single-card movement only** — sequences never move together (Wikipedia's standard rules). Some software offers a "supermove" shortcut that relocates a suited run when enough empty columns exist to have done it card by card; the app keeps the by-the-book rule, so every multi-card relocation is played — and paid for — one move at a time.
-- **Build down by suit**, not by alternating colors — the strict classic rule; color building is a different, much easier game.
+Where the linked sources offer relaxations, this implementation uses:
+- **Single-card movement only.** Sequences never move together (Wikipedia's standard rules). Some software offers a "supermove" shortcut that relocates a suited run when enough empty columns exist to have done it card by card. The app keeps the by-the-book rule, so every multi-card relocation is played — and paid for — one move at a time.
+- **Build down by suit**, not by alternating colors. This is the strict classic rule — color building is a different, much easier game.
 - **Any card fills an empty column** (universal across sources), and columns have no depth limit.
-- **Locked foundations** — a banked card never returns to play. Klondike-style rollbacks would soften the game's defining irreversibility.
-- **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game). The in-app **Redeal** command replays the same deal from the start; it is a fresh attempt at the layout, not a recycle of the stock.
+- **Locked foundations.** A banked card never returns to play. Klondike-style rollbacks would soften the game's defining irreversibility.
+- **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game). The in-app **Redeal** command replays the same deal from the start — a fresh attempt at the layout, not a recycle of the stock.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Napoleon_at_St_Helena

--- a/docs/rules/freecell.md
+++ b/docs/rules/freecell.md
@@ -8,14 +8,14 @@ Move all 52 cards to the four foundations, building each suit from Ace to King.
 ## Terminology
 - **Cascades:** Eight tableau columns where cards are played and rearranged.
 - **Free cells:** Four slots that each hold one card temporarily.
-- **Foundations:** Four suit piles built from Ace to King.
+- **Foundations:** Four suit piles built up from Ace to King.
 - **Supermove:** Moving an ordered run of cards at once, as a shortcut for a series of single-card moves through free cells and empty cascades.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
 - Deal all 52 cards face up across the eight cascades, left to right: the first four cascades receive **7 cards** each, the last four **6 cards** each.
 - The four free cells and four foundations start empty.
-- There is no stock or waste — every card is visible and in play from the start.
+- There is no stock or waste, so every card is visible and in play from the start.
 
 ## Play
 
@@ -23,16 +23,16 @@ Move all 52 cards to the four foundations, building each suit from Ace to King.
 - Build cascades **down in rank** while **alternating colors** (e.g., red 6 on black 7).
 - You may move the **bottom (exposed) card** of a cascade, or a properly ordered run of cards ending with it (see Supermoves below).
 - An exposed card may move to:
-  - another cascade, onto a card one rank higher of the opposite color;
-  - an empty free cell;
-  - its foundation, if it is the next card in that suit's sequence.
-- **Any card** may be placed on an empty cascade — unlike Klondike, empty spaces are not restricted to Kings.
+  - another cascade, onto a card one rank higher of the opposite color
+  - an empty free cell
+  - its foundation, if it is the next card in that suit's sequence
+- **Any card** may be placed on an empty cascade. Unlike Klondike, empty spaces are not restricted to Kings.
 
 ### Free cells
 - Each free cell holds **exactly one card**.
 - Any exposed card may be moved to an empty free cell at any time.
 - A card in a free cell may return to a cascade (following the normal build rule), move to an empty cascade, or move to its foundation.
-- Free cells are the game's main maneuvering space; keeping them open preserves mobility.
+- Free cells are the game's main maneuvering space — keeping them open preserves mobility.
 
 ### Foundations
 - Foundations are built **by suit** from **Ace to King**.
@@ -54,13 +54,13 @@ Formally, FreeCell only allows moving one card at a time. Moving a run of cards 
 - The score never drops below zero.
 
 ## Winning
-You win when all 52 cards are moved to the foundations in ascending order by suit. Because all cards are visible from the deal, FreeCell is a game of near-complete information — of the original 32,000 Microsoft deals, only one (#11982) is unwinnable.
+You win when all 52 cards are moved to the foundations in ascending order by suit. Because all cards are visible from the deal, FreeCell is a game of near-complete information. Of the original 32,000 Microsoft deals, only one (#11982) is unwinnable.
 
 ## Rule choices
-FreeCell's rules are essentially settled; the decisions this implementation makes:
-- **Any card on an empty cascade** (standard FreeCell; some variants restrict empty columns).
+FreeCell's rules are essentially settled. The decisions this implementation makes:
+- **Any card on an empty cascade** (standard FreeCell, though some variants restrict empty columns).
 - **The strict supermove cap**, including the rule that a run's empty destination cascade doesn't count as maneuvering space for its own move.
-- **Time-and-completion scoring** — classic FreeCell awards no per-move points, so the win time bonus is the whole score.
+- **Time-and-completion scoring.** Classic FreeCell awards no per-move points, so the win time bonus is the whole score.
 
 ## Sources
 - https://en.wikipedia.org/wiki/FreeCell

--- a/docs/rules/golf.md
+++ b/docs/rules/golf.md
@@ -1,19 +1,19 @@
 # Golf Rules
 
-These rules describe Golf as implemented in the app: strict classic Golf — exposed column cards one rank above or below the waste top are played onto it, with no wraparound, a draw-one stock, and a single pass — scored like its namesake across a nine-hole match. The published sources offer several relaxations; the choices made here (and why) are called out below.
+These rules describe Golf as implemented in the app: strict classic Golf, where exposed column cards one rank above or below the waste top are played onto it, with no wraparound, a draw-one stock, and a single pass, scored like its namesake across a nine-hole match. The published sources offer several relaxations — the choices made here (and why) are called out below.
 
 ## Objective
-Clear all 35 column cards by playing them onto the waste, one rank up or down at a time, in as few strokes as possible. The stock and waste do **not** need to be emptied. A hole's score is the cards left on the board — or better, below zero for a cleared board — and nine holes make a match. Lower is better throughout.
+Clear all 35 column cards by playing them onto the waste, one rank up or down at a time, in as few strokes as possible. The stock and waste do **not** need to be emptied. A hole's score is the cards left on the board (or below zero for a cleared board), and nine holes make a match. Lower is better throughout.
 
 ## Terminology
-- **Columns:** Seven face-up piles of five cards; only each column's exposed (last-dealt) card may play.
-- **Stock:** The face-down draw pile (16 cards after the deal). One pass only — there are no recycles.
-- **Waste:** The face-up pile every played and drawn card lands on; its top card is the match target.
+- **Columns:** Seven face-up piles of five cards — only each column's exposed (last-dealt) card may play.
+- **Stock:** The face-down draw pile (16 cards after the deal). You get one pass through it — no recycles.
+- **Waste:** The face-up pile every played and drawn card lands on — its top card is the match target.
 - **Hole:** One deal. Nine holes make a match.
-- **Par:** 45 strokes for a nine-hole match — five per hole, matching a hole where a straightforward game clears most of the board.
+- **Par:** 45 strokes for a nine-hole match, five per hole, matching a hole where a straightforward game clears most of the board.
 
 ## Card Values
-Rank order runs Ace, 2 … 10, Jack, Queen, King, and does **not** wrap: an Ace connects only to a 2, and a King only to a Queen. Nothing may be played on a King — once a King tops the waste, only a stock flip revives the board. Suits never matter.
+Rank order runs Ace, 2 … 10, Jack, Queen, King, and does **not** wrap: an Ace connects only to a 2, and a King only to a Queen. Nothing may be played on a King — once one tops the waste, only a stock flip revives the board. Suits never matter.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
@@ -24,26 +24,26 @@ Rank order runs Ace, 2 … 10, Jack, Queen, King, and does **not** wrap: an Ace 
 ## Play
 - Play any **exposed** column card that is one rank above or below the top waste card, regardless of suit. It becomes the new match target.
 - Ranks never wrap, and nothing plays on a King.
-- Tap the stock to flip **one** card onto the waste. The stock allows a **single pass** — there are no recycles.
+- Tap the stock to flip **one** card onto the waste. You get a **single pass** through the stock — no recycles.
 - Cards never leave the waste, and there is no building.
 - The hole ends when the board is cleared, or when the stock is spent and nothing plays.
 
 ## Scoring
-- Your hole score is the number of cards still on the board — it starts at 35 and each play removes a stroke.
-- Flipping a stock card costs nothing; its price is the plays it didn't make.
+- Your hole score is the number of cards still on the board. It starts at 35 and each play removes a stroke.
+- Flipping a stock card costs nothing — its price is the plays it didn't make.
 - Clearing the board subtracts one point per stock card left, so scores below zero are the best results.
 - There is no time bonus — strokes are the whole score.
-- A match is nine consecutive holes; the totals sum, and par for the match is 45.
-- **New Game** abandons the match and starts a fresh one at hole 1; **Redeal** replays the current hole. Switching games keeps the match — every game's session is stashed, and Golf resumes where it left off.
+- A match is nine consecutive holes. The totals sum, and par for the match is 45.
+- **New Game** abandons the match and starts a fresh one at hole 1. **Redeal** replays the current hole. Switching games keeps the match — every game's session is stashed, and Golf resumes where it left off.
 
 ## Winning
-You win a hole the moment the last column card is played, regardless of the stock and waste. Most holes are not winnable under strict rules — that is the classic game — so the match score is the real contest: clear what the deal allows and beat par across nine holes.
+You win a hole the moment the last column card is played, regardless of the stock and waste. Most holes are not winnable under strict rules (that is the classic game), so the match score is the real contest: clear what the deal allows and beat par across nine holes.
 
 ## Rule choices
-The linked sources offer relaxations; this implementation uses:
-- **Strict adjacency** — no Ace↔King wraparound and nothing plays on a King (Wikipedia's standard rules). The relaxed "Turn the Corner" variant raises winnability dramatically but is a different, easier game.
+Where the linked sources offer relaxations, this implementation uses:
+- **Strict adjacency.** No wraparound between Ace and King, and nothing plays on a King (Wikipedia's standard rules). The relaxed "Turn the Corner" variant raises winnability dramatically but is a different, easier game.
 - **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game).
-- **Traditional golf scoring** — one stroke per card left, minus one per banked stock card on a clear, totaled across a nine-hole match with par at 45 (Wikipedia's scoring). Lower is better, unlike every other variant in the app, and this is the app's only multi-deal structure.
+- **Traditional golf scoring.** One stroke per card left, minus one per banked stock card on a clear, totaled across a nine-hole match with par at 45 (Wikipedia's scoring). Lower is better, unlike every other variant in the app, and this is the app's only multi-deal structure.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Golf_(patience)

--- a/docs/rules/klondike.md
+++ b/docs/rules/klondike.md
@@ -7,13 +7,13 @@ Move all 52 cards to the four foundations, building each suit from Ace to King.
 
 ## Terminology
 - **Tableau:** Seven piles where cards are played and rearranged.
-- **Foundations:** Four suit piles built from Ace to King.
-- **Stock:** Face-down draw pile.
-- **Waste:** Face-up discard pile from the stock.
+- **Foundations:** Four suit piles built up from Ace to King.
+- **Stock:** The face-down draw pile.
+- **Waste:** Face-up cards turned from the stock — only the top card is playable.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
-- **Tableau:** Deal seven piles left to right. The first pile has 1 card face up; the second has 2 cards (top card face up); continue until the seventh pile has 7 cards with only the top card face up.
+- **Tableau:** Deal seven piles left to right. The first pile has 1 card, the second 2, and so on to the seventh with 7 — only each pile's top card is face up.
 - **Foundations:** Four empty piles, one per suit.
 - **Stock:** Remaining cards are placed face down.
 - **Waste:** Empty pile beside the stock.
@@ -49,10 +49,10 @@ Move all 52 cards to the four foundations, building each suit from Ace to King.
 You win when all cards are moved to the foundations in ascending order by suit.
 
 ## Rule choices
-Published Klondike rules differ mainly in how the stock is handled; this implementation uses:
-- **Unlimited stock passes in both draw modes** — several published rule sets cap 3-card draw at three passes.
-- **The classic −100 recycle penalty in 1-card draw**, where unlimited free passes would otherwise remove the mode's tension; 3-card recycles are free.
-- **Kings only on empty piles** (the standard rule; some variants allow any card).
+Published Klondike rules differ mainly in how the stock is handled. This implementation uses:
+- **Unlimited stock passes in both draw modes.** Several published rule sets cap 3-card draw at three passes.
+- **The classic −100 recycle penalty in 1-card draw**, where unlimited free passes would otherwise remove the mode's tension — 3-card recycles are free.
+- **Kings only on empty piles** (the standard rule, though some variants allow any card).
 
 ## Sources
 - https://en.wikipedia.org/wiki/Klondike_(solitaire)#Rules

--- a/docs/rules/pyramid.md
+++ b/docs/rules/pyramid.md
@@ -1,16 +1,16 @@
 # Pyramid Rules
 
-These rules describe Pyramid as implemented in the app: pairs of exposed cards totaling 13 are removed from a 28-card pyramid, with a draw-one stock and up to three passes. The published sources disagree on several points; the choices made here (and why) are called out below.
+These rules describe Pyramid as implemented in the app: pairs of exposed cards totaling 13 are removed from a 28-card pyramid, with a draw-one stock and up to three passes. The published sources disagree on several points — the choices made here (and why) are called out below.
 
 ## Objective
 Remove all 28 pyramid cards by discarding exposed pairs whose ranks total 13, and Kings alone. The stock and waste do **not** need to be emptied.
 
 ## Terminology
-- **Pyramid:** Twenty-eight face-up cards in seven overlapping rows; each card except the bottom row is covered by two cards below it.
+- **Pyramid:** Twenty-eight face-up cards in seven overlapping rows — each card except the bottom row is covered by two cards below it.
 - **Exposed:** A card with neither covering card remaining. Only exposed cards can be played.
 - **Stock:** The face-down draw pile (24 cards after the deal).
-- **Waste:** Face-up cards drawn from the stock; only the top card is playable.
-- **Discard:** Where removed pairs and Kings go; cards there are out of play permanently.
+- **Waste:** Face-up cards drawn from the stock — only the top card is playable.
+- **Discard:** Where removed pairs and Kings go — cards there are out of play permanently.
 - **Recycle:** Turning the exhausted stock's waste back into the stock for another pass.
 
 ## Card Values
@@ -18,7 +18,7 @@ Ace = 1, number cards = face value, Jack = 11, Queen = 12, King = 13.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
-- **Pyramid:** Deal 28 cards face up in seven rows — one card in the first row, two in the second, and so on to seven — each row overlapping the row above.
+- **Pyramid:** Deal 28 cards face up in seven rows, one card in the first row, two in the second, and so on to seven, with each row overlapping the row above.
 - **Stock:** The remaining 24 cards, face down.
 
 ## Play
@@ -26,22 +26,22 @@ Ace = 1, number cards = face value, Jack = 11, Queen = 12, King = 13.
 - **Kings** total 13 alone and are removed singly.
 - **Cover pair:** a pyramid card whose only remaining cover is its rank-13 partner (itself exposed) may be removed together with it in one move.
 - Tap the stock to draw **one** card to the waste.
-- When the stock is empty, the waste may be recycled into the stock — at most **twice** (three passes total). Recycling preserves draw order.
+- When the stock is empty, the waste may be recycled into the stock at most **twice** (three passes total). Recycling preserves draw order.
 - Gaps in the pyramid are never refilled, and there is no building.
 
 ## Scoring
 - Removing a pair: +10.
 - Removing a King: +5.
-- No recycle penalty — the pass limit is the cost.
-- On a win, a time bonus is added (same basis as the other stockless-choice variants).
+- There is no recycle penalty — the pass limit is the cost.
+- On a win, a time bonus is added: it starts at 900 and drops by one point per second of play.
 
 ## Winning
 You win the moment the last pyramid card is removed, regardless of the stock and waste.
 
 ## Rule choices
-The linked sources disagree; this implementation uses:
+Where the linked sources disagree, this implementation uses:
 - **Win = pyramid cleared** (cardgames.io, solitaired.com, and most digital implementations), not Wikipedia's strict all-52-cards variant (~1 in 50 winnable).
-- **Three passes** through the stock (solitaired.com; Wikipedia's "Par Pyramid"), not one pass (strict) or unlimited (cardgames.io).
+- **Three passes** through the stock (solitaired.com and Wikipedia's "Par Pyramid"), not one pass (strict) or unlimited (cardgames.io).
 - **Cover pairs allowed** (cardgames.io and most digital implementations).
 
 ## Sources

--- a/docs/rules/scorpion.md
+++ b/docs/rules/scorpion.md
@@ -1,19 +1,19 @@
 # Scorpion Rules
 
-These rules describe Scorpion as implemented in the app: **one deck** across **seven tableau piles**, cards building down **by suit** while any face-up card moves with everything stacked on it, and the goal of assembling — and automatically banking — **four full King-to-Ace runs**, one per suit, built in place. A **three-card stock** deals onto the first three piles, once, at any time.
+These rules describe Scorpion as implemented in the app: **one deck** across **seven tableau piles**, cards building down **by suit** while any face-up card moves with everything stacked on it, and the goal of assembling **four full King-to-Ace runs**, one per suit, built in place and banked automatically as they complete. A **three-card stock** deals onto the first three piles, once, at any time.
 
 ## Objective
-Complete four King-to-Ace runs, one per suit, built in place on the tableau. Each completed run is removed from the tableau automatically; the game is won when all four are done.
+Complete four King-to-Ace runs, one per suit, built in place on the tableau. Each completed run is removed from the tableau automatically — the game is won when all four are done.
 
 ## Terminology
 - **Tableau:** Seven piles where all building happens.
 - **Group move:** Any face-up card together with every card stacked on top of it, moved as one, even out of order. Only the selected (bottom) card must connect at the destination.
-- **Completed run:** A full King-to-Ace run of one suit at the end of a pile; it leaves the tableau on its own. Four complete the game.
-- **Stock:** Three face-down cards, dealt face up onto the first three piles at any time — once.
+- **Completed run:** A full King-to-Ace run of one suit at the end of a pile — it leaves the tableau on its own. Four complete the game.
+- **Stock:** Three face-down cards, dealt face up onto the first three piles at any time — but only once.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
-- **Tableau:** Deal 49 cards into seven piles of seven. In each of the **first four piles** the bottom three cards are face down; the **last three piles** are entirely face up.
+- **Tableau:** Deal 49 cards into seven piles of seven. In each of the **first four piles** the bottom three cards are face down, while the **last three piles** are entirely face up.
 - **Stock:** The remaining 3 cards, face down.
 - **Completed runs:** Four spaces bank finished runs as they leave the tableau.
 
@@ -26,8 +26,8 @@ Complete four King-to-Ace runs, one per suit, built in place on the tableau. Eac
 - When a face-down card becomes the top of its pile, it flips face up.
 
 ### The stock
-- Tapping the stock deals its **three cards face up, one onto each of the first three piles** — empty or mid-run piles included.
-- The stock may be dealt **at any time**, but only once; there is no waste and no redeal.
+- Tap the stock to deal its **three cards face up, one onto each of the first three piles**, empty or mid-run piles included.
+- The stock may be dealt **at any time** — but only once. There is no waste and no redeal.
 
 ### Completed runs
 - The moment a pile's top thirteen cards form a face-up King-to-Ace run of one suit, the run is **removed automatically** and banked.
@@ -44,11 +44,11 @@ Complete four King-to-Ace runs, one per suit, built in place on the tableau. Eac
 You win the moment the fourth run banks. The game is lost when the stock is spent and no legal move remains before all four runs are complete.
 
 ## Rule choices
-Published Scorpion rules genuinely disagree on what happens to finished runs and when the stock may be dealt; this implementation uses:
-- **Automatic banking of completed runs** — the common digital convention, matching this app's Spider — rather than the traditional description that leaves finished runs lying in the tableau.
+Published Scorpion rules genuinely disagree on what happens to finished runs and when the stock may be dealt. This implementation uses:
+- **Automatic banking of completed runs.** The common digital convention, matching this app's Spider, rather than the traditional description that leaves finished runs lying in the tableau.
 - **Deal the stock at any time** (Solitaire Network's "or sooner if desired" and most digital versions), not only when play is blocked.
-- **Kings only** on empty piles (universal for Scorpion; the any-card variant is a different game, Wasp).
-- **Three face-down cards in each of the first four piles** (the standard deal; Scorpion II, which hides cards in only three piles, is not implemented).
+- **Kings only** on empty piles (universal for Scorpion — the any-card variant is a different game, Wasp).
+- **Three face-down cards in each of the first four piles** (the standard deal — Scorpion II, which hides cards in only three piles, is not implemented).
 
 ## Sources
 - https://en.wikipedia.org/wiki/Scorpion_(solitaire)

--- a/docs/rules/spider.md
+++ b/docs/rules/spider.md
@@ -1,16 +1,16 @@
 # Spider Rules
 
-These rules describe Spider as implemented in the app: **two decks (104 cards)** across **ten tableau piles**, cards building down regardless of suit while only same-suit runs move together, and the goal of assembling — and automatically banking — **eight full King-to-Ace runs**, one suit each.
+These rules describe Spider as implemented in the app: **two decks (104 cards)** across **ten tableau piles**, cards building down regardless of suit while only same-suit runs move together, and the goal of assembling **eight full King-to-Ace runs**, one suit each, which bank automatically as they complete.
 
 ## Objective
-Complete eight King-to-Ace runs of a single suit. Each completed run is removed from the tableau automatically; the game is won when all eight are done.
+Complete eight King-to-Ace runs of a single suit. Each completed run is removed from the tableau automatically — the game is won when all eight are done.
 
 ## Terminology
 - **Tableau:** Ten piles where cards are played and rearranged.
-- **Run:** Face-up cards of one suit in strict descending order; the only multi-card unit that moves together.
-- **Completed run:** A full King-to-Ace run of one suit; it leaves the tableau on its own.
+- **Run:** Face-up cards of one suit in strict descending order — the only multi-card unit that moves together.
+- **Completed run:** A full King-to-Ace run of one suit — it leaves the tableau on its own.
 - **Stock:** The face-down pile that deals one card onto every tableau pile at once.
-- **Suits (difficulty):** The two decks are composed of 1, 2, or 4 distinct suits — always 104 cards.
+- **Suits (difficulty):** The two decks are composed of 1, 2, or 4 distinct suits, always 104 cards.
 
 ## Setup
 - Use two standard 52-card decks (no jokers). Difficulty changes the composition: **1 suit** (eight sets of Spades), **2 suits** (four sets each of Spades and Hearts), or **4 suits** (two full decks).
@@ -28,7 +28,7 @@ Complete eight King-to-Ace runs of a single suit. Each completed run is removed 
 - When the last face-up card leaves a pile, flip the newly exposed face-down card face up.
 
 ### The stock
-- Tapping the stock deals **one face-up card onto every pile** (ten cards per deal; five deals in a game).
+- Tap the stock to deal **one face-up card onto every pile** (ten cards per deal, five deals in a game).
 - Dealing is **not allowed while any pile is empty** — fill every space first.
 
 ### Completed runs
@@ -43,13 +43,13 @@ Complete eight King-to-Ace runs of a single suit. Each completed run is removed 
 - The score never drops below zero.
 
 ## Winning
-You win when all eight runs are completed. With good play, roughly one in three 4-suit games is winnable; 2-suit games considerably more, and 1-suit games almost always.
+You win when all eight runs are completed. With good play, roughly one in three 4-suit games is winnable, 2-suit games considerably more, and 1-suit games almost always.
 
 ## Rule choices
-Published Spider rules differ in scoring and stock handling; this implementation uses:
-- **Classic Spider scoring** — the 500-point start with −1 per move and +100 per run, rather than per-card schemes some sites use.
-- **Deals blocked over empty piles** (the standard rule; some implementations allow dealing across gaps).
-- **Suit-count difficulty** as deck composition — 1, 2, or 4 suits always totaling 104 cards, each mode keeping its own statistics.
+Published Spider rules differ in scoring and stock handling. This implementation uses:
+- **Classic Spider scoring.** The 500-point start with −1 per move and +100 per run, rather than the per-card schemes some sites use.
+- **Deals blocked over empty piles** (the standard rule, though some implementations allow dealing across gaps).
+- **Suit-count difficulty** as deck composition. The two decks are made of 1, 2, or 4 suits, always totaling 104 cards, and each mode keeps its own statistics.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Spider_(solitaire)

--- a/docs/rules/tripeaks.md
+++ b/docs/rules/tripeaks.md
@@ -1,23 +1,23 @@
 # TriPeaks Rules
 
-These rules describe TriPeaks as implemented in the app: uncovered peak cards one rank above or below the waste top are played onto it, with a draw-one stock and a single pass. The published sources disagree on several points; the choices made here (and why) are called out below.
+These rules describe TriPeaks as implemented in the app: uncovered peak cards one rank above or below the waste top are played onto it, with a draw-one stock and a single pass. The published sources disagree on several points — the choices made here (and why) are called out below.
 
 ## Objective
 Clear all 28 peak cards by playing them onto the waste, one rank up or down at a time. The stock and waste do **not** need to be emptied.
 
 ## Terminology
-- **Peaks:** Twenty-eight cards in three overlapping peaks — face-down rows of three, six, and nine over a face-up base row of ten; each card except the base row is covered by two cards below it.
+- **Peaks:** Twenty-eight cards in three overlapping peaks, with face-down rows of three, six, and nine over a face-up base row of ten. Each card except the base row is covered by two cards below it.
 - **Uncovered:** A card with neither covering card remaining. Only uncovered cards can be played.
 - **Stock:** The face-down draw pile (23 cards after the deal).
-- **Waste:** The face-up pile every played and drawn card lands on; its top card is the match target.
-- **Chain:** Consecutive discards without flipping the stock; each discard in a chain is worth one more point than the last.
+- **Waste:** The face-up pile every played and drawn card lands on — its top card is the match target.
+- **Chain:** Consecutive discards without flipping the stock — each discard in a chain is worth one more point than the last.
 
 ## Card Values
 Rank order runs Ace, 2 … 10, Jack, Queen, King, and wraps around: King and Ace are adjacent, as are Ace and 2. Suits never matter.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
-- **Peaks:** Deal 28 cards into the three-peak layout — three face-down rows (three peak cards, then six, then nine), topped by the face-up ten-card base row that the peaks share.
+- **Peaks:** Deal 28 cards into the three-peak layout, with three face-down rows (three peak cards, then six, then nine) under the face-up ten-card base row that the peaks share.
 - **Waste:** Flip one card face up to start the waste.
 - **Stock:** The remaining 23 cards, face down.
 
@@ -25,21 +25,21 @@ Rank order runs Ace, 2 … 10, Jack, Queen, King, and wraps around: King and Ace
 - Play any **uncovered** card that is one rank above or below the top waste card, regardless of suit. It becomes the new match target.
 - Ranks **wrap**: a King plays on an Ace, and an Ace plays on a King or a Two.
 - A face-down card flips face up the moment both cards covering it are removed.
-- Tap the stock to flip **one** card onto the waste. The stock allows a **single pass** — there are no recycles.
+- Tap the stock to flip **one** card onto the waste. You get a **single pass** through the stock — no recycles.
 - Cards never leave the waste, and there is no building.
 
 ## Scoring
 - The n-th consecutive discard in a chain: +n (1, 2, 3, …).
 - Flipping a stock card: −5, and the chain resets.
-- Clearing a peak: +15 for each of the first two; the third — which always clears the board — pays +30 instead.
-- On a win, a time bonus is added (same basis as the other stockless-choice variants).
+- Clearing a peak: +15 for each of the first two. The third — which always clears the board — pays +30 instead.
+- On a win, a time bonus is added: it starts at 900 and drops by one point per second of play.
 - The score never drops below zero.
 
 ## Winning
 You win the moment the last peak card is played, regardless of the stock and waste.
 
 ## Rule choices
-The linked sources disagree; this implementation uses:
+Where the linked sources disagree, this implementation uses:
 - **Wrapping allowed** (cardgames.io/semicolon.com and most digital implementations, including the original 1989 game), not the no-wrap variant some sites reserve for their "hard" mode.
 - **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game).
 - **Chain scoring with peak bonuses** (the conventional scheme from the original game: escalating discards, −5 flips, 15/15/30 peak bonuses), not plain per-card scoring.

--- a/docs/rules/yukon.md
+++ b/docs/rules/yukon.md
@@ -1,26 +1,26 @@
 # Yukon Rules
 
-These rules describe Yukon as implemented in the app. Yukon resembles Klondike — same tableau building and foundation rules, with face-down cards to uncover — but all 52 cards are dealt at the start (there is no stock or waste), and any face-up card may be moved together with every card stacked on top of it, **even if those cards are not in sequence**.
+These rules describe Yukon as implemented in the app. Yukon resembles Klondike in its tableau building and foundation rules, with face-down cards to uncover, but all 52 cards are dealt at the start (there is no stock or waste), and any face-up card may be moved together with every card stacked on top of it, **even if those cards are not in sequence**.
 
 ## Objective
 Move all 52 cards to the four foundations, building each suit from Ace to King.
 
 ## Terminology
 - **Tableau:** Seven piles where cards are played and rearranged.
-- **Foundations:** Four suit piles built from Ace to King.
+- **Foundations:** Four suit piles built up from Ace to King.
 - **Group move:** Moving a face-up card together with every card above it as one unit, regardless of order.
 
 ## Setup
 - Use a standard 52-card deck (no jokers).
-- **Tableau:** Deal seven piles left to right. The first pile has 1 card face up. Each following pile has one more face-down card than the last — 1 through 6 — with **5 cards face up** on top of them, so the piles hold 1, 6, 7, 8, 9, 10, and 11 cards.
+- **Tableau:** Deal seven piles left to right. The first pile has 1 card face up. Each following pile has one more face-down card than the last (1 through 6), with **5 cards face up** on top of them, so the piles hold 1, 6, 7, 8, 9, 10, and 11 cards.
 - **Foundations:** Four empty piles, one per suit.
-- All 52 cards are dealt (21 face down, 31 face up); there is no stock or waste.
+- All 52 cards are dealt (21 face down, 31 face up) — there is no stock or waste.
 
 ## Play
 
 ### Tableau
 - Build tableau piles **down in rank** while **alternating colors** (e.g., red 6 on black 7).
-- **Any face-up card may be moved**, carrying every card stacked on top of it along as a group — the group does **not** need to be in any order.
+- **Any face-up card may be moved**, carrying every card stacked on top of it along as a group. The group does **not** need to be in any order.
 - Only the **bottom card of the moving group** must fit the destination: one rank lower and the opposite color of the destination pile's top card.
 - When the last face-up card leaves a pile, flip the newly exposed face-down card face up.
 - Empty tableau spaces may be filled **only by a King** (alone or carrying a group).
@@ -28,7 +28,7 @@ Move all 52 cards to the four foundations, building each suit from Ace to King.
 ### Foundations
 - Foundations are built **by suit** from **Ace to King**.
 - Aces start each foundation pile.
-- Only one card at a time moves to a foundation — the top card of a tableau pile.
+- Only the top card of a tableau pile moves to a foundation, one card at a time.
 
 ### Group moves
 Group moves are what set Yukon apart:
@@ -45,13 +45,13 @@ Group moves are what set Yukon apart:
 - The score never drops below zero.
 
 ## Winning
-You win when all 52 cards are moved to the foundations in ascending order by suit. With no stock to cycle and most cards visible or discoverable through play, skilled play wins considerably more often than in Klondike — roughly 80% of deals are estimated to be winnable with best play.
+You win when all 52 cards are moved to the foundations in ascending order by suit. With no stock to cycle and most cards visible or discoverable through play, skilled play wins considerably more often than in Klondike. Roughly 80% of deals are estimated to be winnable with best play.
 
 ## Rule choices
-Yukon's play rules are essentially settled; the decisions this implementation makes:
-- **Kings only on empty piles** (the standard Yukon rule; some variants allow any card or group).
-- **Foundation rollbacks allowed** at −15, matching Klondike — pulling a banked card back down is sometimes the only way to untangle a pile.
-- **Klondike-style scoring minus the waste rows** — Yukon has no stock or waste, so only the foundation, reveal, and rollback values apply.
+Yukon's play rules are essentially settled. The decisions this implementation makes:
+- **Kings only on empty piles** (the standard Yukon rule, though some variants allow any card or group).
+- **Foundation rollbacks allowed** at −15, matching Klondike. Pulling a banked card back down is sometimes the only way to untangle a pile.
+- **Klondike-style scoring minus the waste rows.** Yukon has no stock or waste, so only the foundation, reveal, and rollback values apply.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Yukon_(solitaire)


### PR DESCRIPTION
## What Changed

- Reordered game presentation to match the agreed popularity ranking.
- Assigned Command-0 through Command-9 to the ten game variants in presentation order.
- Moved destructive statistics reset actions out of the crowded iOS toolbar and into the form.
- Updated the About copy and README game ordering.
- Polished all user-facing rules verbiage in the Rules & Scoring screen and the ten rules docs: one consistent voice for shared concepts (stock passes, foundation building, win conditions), friendlier second-person phrasing, and a Klondike setup bullet that was missing.
- Rewrote the README variants table as plain, factual descriptions.
- Standardized punctuation across all user-facing text: em dashes only where they strengthen a sentence, no semicolons, restructured sentences elsewhere.

## Why

Game discovery, keyboard shortcuts, statistics navigation, and About content should consistently reflect the current set of games without overcrowding compact iOS toolbars. The rules text had drifted variant to variant in voice and terminology, and the README variant descriptions read more like marketing copy than reference.

Closes #59

## UI Changes

- Game lists now show Pyramid before TriPeaks and Yukon and Scorpion before Forty Thieves.
- Statistics screens retain a compact iOS header while keeping reset actions visible at the bottom.
- About now mentions Spider alongside Klondike and FreeCell.
- Rules & Scoring text is reworded throughout; layout is unchanged.

## Validation

- iOS and iPadOS generic device build succeeded.
- macOS build succeeded.
- `GolfMatchTests` (23 tests) pass on macOS, covering the par standing format.
- Verified no semicolons remain in user-facing strings, rules docs, or the README.
- `git diff --check` succeeded.