### PR TITLE
Make the game picker's overflow read as scrollable

### DIFF
--- a/ComputerSolitaire/Views/Shared/GameModePickerView.swift
+++ b/ComputerSolitaire/Views/Shared/GameModePickerView.swift
@@ -258,6 +258,16 @@ struct GameModePickerOverlay: View {
     @FocusState private var isPickerFocused: Bool
     @AccessibilityFocusState private var isPickerAccessibilityFocused: Bool
 
+    /// Which panel edges have more content scrolled beyond them, driving the
+    /// edge fades. The bottom starts true because the scrolling fallback only
+    /// exists when the content overflows.
+    @State private var overflowingEdges = OverflowingEdges(top: false, bottom: true)
+
+    private struct OverflowingEdges: Equatable {
+        var top: Bool
+        var bottom: Bool
+    }
+
     var body: some View {
         ZStack {
             // The scrim is the picker's cancel button: clicking outside the
@@ -270,15 +280,14 @@ struct GameModePickerOverlay: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Dismiss game picker")
 
-            // Short windows (macOS near its minimum size, phone landscape,
-            // large accessibility text) can't fit the whole picker; fall back
-            // to scrolling the same content rather than clipping it.
+            // Short windows (a ten-family gallery on a phone, macOS near its
+            // minimum size, large accessibility text) can't fit the whole
+            // picker; fall back to scrolling the same content, opened at the
+            // current game and faded at whichever edges hide more of it.
             ViewThatFits(in: .vertical) {
                 picker
 
-                ScrollView {
-                    picker
-                }
+                scrollingPicker
             }
             .frame(maxWidth: 360)
             .background(
@@ -317,6 +326,52 @@ struct GameModePickerOverlay: View {
             cardBackColor: CardBackColor.from(rawValue: cardBackColorRawValue),
             onSelect: onSelect
         )
+    }
+
+    private var scrollingPicker: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                picker
+            }
+            .onScrollGeometryChange(for: OverflowingEdges.self) { geometry in
+                OverflowingEdges(
+                    top: geometry.contentOffset.y > 1,
+                    bottom: geometry.contentOffset.y + geometry.containerSize.height
+                        < geometry.contentSize.height - 1
+                )
+            } action: { _, edges in
+                overflowingEdges = edges
+            }
+            .mask(edgeFadeMask)
+            .onAppear {
+                // Land on the current game: a below-the-fold selection scrolls
+                // just into view, a visible one stays put.
+                proxy.scrollTo(currentMode.variant)
+            }
+        }
+    }
+
+    /// Fades the content at each edge that hides more of it, so the fold
+    /// reads as "scroll for more" instead of an accidental clip.
+    private var edgeFadeMask: some View {
+        VStack(spacing: 0) {
+            LinearGradient(
+                colors: [.black.opacity(overflowingEdges.top ? 0 : 1), .black],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 24)
+
+            Color.black
+
+            LinearGradient(
+                colors: [.black, .black.opacity(overflowingEdges.bottom ? 0 : 1)],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .frame(height: 24)
+        }
+        .animation(.easeInOut(duration: 0.15), value: overflowingEdges)
     }
 }
 


### PR DESCRIPTION
## What Changed
- The game picker's scrolling fallback now fades the content at whichever panel edges hide more of it, driven by `onScrollGeometryChange`, so the fold reads as "scroll for more" instead of an accidental mid-row clip.
- When the picker opens in its scrolling state, it scrolls the current game just into view; an already-visible selection stays put.
- The non-scrolling presentation (windows tall enough to fit every family) is unchanged, as are the family rows themselves.

## Why
With ten game families, the gallery overflows a phone screen. The existing `ViewThatFits` fallback scrolled correctly but gave no cue that it did: the panel clipped Forty Thieves mid-row with no fade or indicator, so the games below the fold — including the newest variants — looked cut off rather than reachable. This also scales to future variants without revisiting the layout.

## Validation
- Full test suite on macOS: 541 tests, 0 failures.
- Debug builds succeed for iOS simulator and macOS destinations.
- Verified on the iPhone 17 Pro simulator: bottom fade on open, fade handoff between edges while scrolling, fades releasing at either end, and the picker opening scrolled to Canfield when Canfield is the current game.

## UI Changes
- Scrolling picker only: 24pt gradient fades at overflowing panel edges (0.15s ease as they engage/release), and the initial scroll position lands on the current game. No changes to row layout, spacing, or the fits-without-scrolling presentation.