### PR TITLE
Declare exempt encryption use

### DIFF
--- a/ComputerSolitaire/Info.plist
+++ b/ComputerSolitaire/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>ITSAppUsesNonExemptEncryption</key>
+	<false/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>remote-notification</string>


### PR DESCRIPTION
## What Changed

- Set `ITSAppUsesNonExemptEncryption` to `false` in the app information property list.

## Why

- Declare that the app does not use non-exempt encryption so App Store Connect can skip repeated export-compliance questions for future uploads.

## Validation

- `plutil -lint ComputerSolitaire/Info.plist`
- `git diff --check`
- macOS Debug build using the repository's documented `xcodebuild` command