### PR TITLE
Upgrade Pages artifact action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -362,7 +362,7 @@ jobs:
           cat site/appcast.xml
 
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v5
         with:
           path: site
 


### PR DESCRIPTION
## What Changed

- Upgrade `actions/upload-pages-artifact` from v4 to v5 in the release workflow.

## Why

The v4 action internally pins `actions/upload-artifact@v4`, which targets deprecated Node.js 20. Version 5 uses `actions/upload-artifact@v7`, eliminating the deprecation warning on GitHub Actions runners.

## Validation

- Parsed all GitHub Actions workflow YAML files successfully.
- Ran `git diff --check` successfully.
- Verified the upstream v5 action resolves to `actions/upload-artifact@v7.0.0`.