### PR TITLE
Host the bottom bar in a navigation stack

### DIFF
--- a/ComputerSolitaire/Views/Shared/ContentView.swift
+++ b/ComputerSolitaire/Views/Shared/ContentView.swift
@@ -12,15 +12,18 @@ struct DropTargetFrameKey: PreferenceKey {
     }
 }
 
-// Single-frame keys must ignore the default: on macOS, sibling subtrees that
-// never set the key still run reduce with .zero, and a last-wins reducer lets
-// that erase the real frame (the draw animation then never runs).
+// Single-frame keys must ignore sizeless candidates: sibling subtrees that
+// never set the key still run reduce, and a last-wins reducer lets them erase
+// the real frame (the draw animation then never runs). Rejecting only `.zero`
+// is not enough — a subtree measured before layout reports a rect with a real
+// origin but no size, e.g. `(148, 0, 0 x 0)`, which clears that test and
+// clobbers the live frame. Size is what makes a candidate meaningful here.
 struct StockFrameKey: PreferenceKey {
     static var defaultValue: CGRect = .zero
 
     static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
         let next = nextValue()
-        if next != .zero {
+        if !next.isEmpty {
             value = next
         }
     }
@@ -31,7 +34,7 @@ struct WasteFrameKey: PreferenceKey {
 
     static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
         let next = nextValue()
-        if next != .zero {
+        if !next.isEmpty {
             value = next
         }
     }
@@ -255,11 +258,34 @@ struct ContentView: View {
         }
     }
 
+    /// Gives the bottom bar a real navigation host on iOS.
+    ///
+    /// `.bottomBar` expects to be owned by a navigation container. Hosted bare
+    /// in the `WindowGroup` the items are bridged onto the window root, where
+    /// board mutations tear the bar down and `.toolbar(_:for: .bottomBar)` has
+    /// nothing to act on — which is why bar visibility used to be faked by
+    /// emptying the item list.
+    ///
+    /// The stack is purely a host: it never pushes and its own navigation bar
+    /// is hidden. It does add a subtree that reports sizeless frames before
+    /// layout, so the single-frame preference keys reject those explicitly.
+    private func toolbarHost(for view: some View) -> some View {
+#if os(iOS)
+        NavigationStack {
+            view
+                .toolbar(.hidden, for: .navigationBar)
+                .toolbar(isShowingGamePicker ? .hidden : .visible, for: .bottomBar)
+        }
+#else
+        view
+#endif
+    }
+
     // The decoration helpers are generic over their content — never AnyView.
     // Type erasure here would strip the board's structural identity, forcing
     // SwiftUI to diff the whole scene through an opaque box on every update.
     private func sceneDecorations(for baseView: some View) -> some View {
-        let toolbarView = applyToolbar(to: baseView)
+        let toolbarView = toolbarHost(for: applyToolbar(to: baseView))
         let sheetsView = applySheets(to: toolbarView)
         return applyObservers(to: sheetsView)
     }


### PR DESCRIPTION
## What Changed

- Wrap the iOS board in a `NavigationStack` that only ever hosts — it never pushes, and its own navigation bar is hidden so the board keeps the full screen.
- Drive game-picker bar visibility through `.toolbar(_:for: .bottomBar)` instead of conditionally emptying the toolbar's item list.
- Tighten the `StockFrameKey` / `WasteFrameKey` reducers to reject sizeless candidates (`!next.isEmpty`) rather than only the exact `.zero` rect.

macOS is unaffected: `toolbarHost` returns the view unchanged off iOS.

## Why

The bottom toolbar items disappeared completely for a moment on every stock draw.

`ContentView` sits bare in the `WindowGroup` with no navigation container, so `.bottomBar` items were bridged onto the window root, where board mutations tore the bar down and rebuilt it. The same missing host made `.toolbar(.hidden, for: .bottomBar)` inert, which is why hiding the bar behind the picker had to be faked by removing every item — the workaround the old comment described.

Hosting the bar in a navigation stack fixes both, but it exposed a latent bug in the frame preference keys. The stack adds a subtree that is measured before layout and reports a frame with a real origin but no size, e.g. `(148, 0, 0 x 0)`. The reducers guarded with `next != .zero`, which that rect clears, so it overwrote the live stock and waste frames and every card flight launched from the top of the screen instead of the pile. Guarding on size is what the check meant all along; the existing comment shows the same class of bug already occurred once on macOS, and the guard was simply too narrow to catch this variant.

## Validation

- `xcodebuild ... -destination 'generic/platform=macOS' build` succeeds.
- `xcodebuild ... -destination 'platform=macOS' test`: 594 tests, 10 skipped, 0 failures.
- iOS simulator build succeeds.
- `GameModePickerUITests.testTapOutsideDismissesGamePicker` passes: the bar leaves while the picker is open and returns on dismiss, now through the supported visibility API.
- Flight-planner inputs are unchanged with the stack in place, logged on both builds:

  | | before | after |
  |---|---|---|
  | stock | `(12, 114.667, 47 x 68.15)` | `(12, 114.667, 47 x 68.15)` |
  | waste | `(67, 114.667, 63.92 x 68.15)` | `(67, 114.667, 63.92 x 68.15)` |

- Screen recording of stock draws confirms cards fly from the stock pile to the waste, not from the top of the screen.
- Toolbar flicker confirmed resolved on device.

## UI Changes

- The bottom toolbar no longer blanks and reappears when drawing from the stock.
- No visual or layout change otherwise: the same items in the same order, and Auto Finish keeps its existing show/hide behavior.