### PR TITLE
Improve pixel pip sprites

### DIFF
--- a/ComputerSolitaire/Views/Cards/Styles/PixelCardViews.swift
+++ b/ComputerSolitaire/Views/Cards/Styles/PixelCardViews.swift
@@ -309,22 +309,24 @@ enum PixelSprites {
     }
 
     // Compact pip suits use an even 6x6 footprint so their origins and centers
-    // stay on whole grid cells across the responsive card layout.
+    // stay on whole grid cells across the responsive card layout. Every row is
+    // horizontally symmetric so the 180-degree rotation used for bottom pips
+    // reads as the same symbol upside down.
     static let spadePip = PixelSprite("""
     ..##..
     .####.
     ######
     ######
-    ##..##
     ..##..
+    .####.
     """)
 
     static let heartPip = PixelSprite("""
-    .##.##
+    ##..##
+    ######
     ######
     ######
     .####.
-    ..##..
     ..##..
     """)
 
@@ -339,11 +341,11 @@ enum PixelSprites {
 
     static let clubPip = PixelSprite("""
     ..##..
-    .####.
+    ..##..
+    ######
     ######
     ..##..
     .####.
-    ..##..
     """)
 
     static func pipSuit(_ suit: Suit) -> PixelSprite {


### PR DESCRIPTION
## What Changed

- Reshaped the compact spade, heart, and club pip sprites used on numbered cards in the Pixel style.
- Documented the horizontal-symmetry invariant for compact pip artwork.

## Why

The compact heart pip had a horizontally offset top row, and the spade and club silhouettes were less clear when reused for the 180-degree-rotated lower pips. Centering each row keeps the symbols visually consistent in both orientations.

## UI Changes

Numbered cards using the Pixel style now show clearer, centered spade, heart, and club pips. The diamond pip, aces, corner indices, face cards, card backs, and other card styles are unchanged.

## Validation

- macOS test suite: 594 tests executed, 10 skipped, 0 failures
- `git diff --check`
- Structured review reported no actionable findings