### PR TITLE
Add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Austin Smith
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,3 @@ Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
 | **Scorpion** | Build down by suit to complete four King-to-Ace runs in place, moving face-up cards with everything stacked on them | [Rules](docs/rules/scorpion.md) |
 | **Forty Thieves** | Build ten columns down by suit, one card at a time, using two decks and a single pass through the stock | [Rules](docs/rules/fortythieves.md) |
 | **Canfield** | Play a 13-card reserve onto foundations that start at a dealt base rank and wrap | [Rules](docs/rules/canfield.md) |
-
-## License
-
-Computer Solitaire is available under the [MIT License](LICENSE).

--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
 | **Scorpion** | Build down by suit to complete four King-to-Ace runs in place, moving face-up cards with everything stacked on them | [Rules](docs/rules/scorpion.md) |
 | **Forty Thieves** | Build ten columns down by suit, one card at a time, using two decks and a single pass through the stock | [Rules](docs/rules/fortythieves.md) |
 | **Canfield** | Play a 13-card reserve onto foundations that start at a dealt base rank and wrap | [Rules](docs/rules/canfield.md) |
+
+## License
+
+Computer Solitaire is available under the [MIT License](LICENSE).


### PR DESCRIPTION
## What Changed

- Added a `LICENSE` file with the MIT License, copyright 2026 Austin Smith

## Why

The repository is public but had no license, which defaults to all rights reserved — nobody can legally use, modify, or redistribute the code. The MIT License makes the code freely reusable while keeping things simple and preserving full relicensing flexibility.

## Validation

Documentation-only change — no source code, project files, or build configuration touched, so build and test workflows do not apply.