### PR TITLE
Improve card presentation across platforms

### DIFF
--- a/ComputerSolitaire/Views/Cards/CardView.swift
+++ b/ComputerSolitaire/Views/Cards/CardView.swift
@@ -17,7 +17,13 @@ enum CardStyle: String, CaseIterable, Identifiable {
     case simple
     case pixel
 
-    static let defaultValue: CardStyle = .simple
+    static var defaultValue: CardStyle {
+#if os(macOS)
+        .classic
+#else
+        .simple
+#endif
+    }
 
     var id: String { rawValue }
 

--- a/ComputerSolitaire/Views/Cards/Styles/SimpleCardViews.swift
+++ b/ComputerSolitaire/Views/Cards/Styles/SimpleCardViews.swift
@@ -60,12 +60,14 @@ struct SimpleCardFrontView: View {
         ZStack {
             SimpleCardBase(fill: SimplePalette.face, chrome: chrome)
 
-            HStack(alignment: .firstTextBaseline, spacing: 0) {
+            HStack(alignment: .top, spacing: 0) {
                 Text(card.rank.label)
-                    .font(.custom("Charter-Bold", size: cardSize.width * 0.27))
+                    .font(.system(size: cardSize.width * 0.35, weight: .semibold, design: .serif))
+                    .fontWidth(.condensed)
                 Spacer(minLength: 0)
                 Image(systemName: card.suit.symbolName)
                     .font(.system(size: cardSize.width * 0.22, weight: .semibold))
+                    .offset(y: cardSize.width * 0.055)
                     .accessibilityHidden(true)
             }
             .foregroundStyle(inkColor)

--- a/ComputerSolitaireTests/Shared/CardStyleTests.swift
+++ b/ComputerSolitaireTests/Shared/CardStyleTests.swift
@@ -3,9 +3,14 @@ import XCTest
 
 @MainActor
 final class CardStyleTests: XCTestCase {
-    func testDefaultStyleIsSimple() {
+    func testDefaultStyleMatchesPlatform() {
+#if os(macOS)
+        XCTAssertEqual(CardStyle.defaultValue, .classic)
+        XCTAssertEqual(CardStyle.defaultValue.rawValue, "classic")
+#else
         XCTAssertEqual(CardStyle.defaultValue, .simple)
         XCTAssertEqual(CardStyle.defaultValue.rawValue, "simple")
+#endif
     }
 
     func testOnlyCurrentRawValuesResolveToStyles() {


### PR DESCRIPTION
## What Changed

- Enlarged Simple card ranks with a condensed semibold serif treatment and optically aligned the smaller corner suit.
- Defaulted to Simple cards on iOS and iPadOS and Classic cards on macOS while preserving saved selections.
- Updated default-style test coverage for each platform.

## Why

Improve rank legibility on compact mobile cards while keeping the card face balanced and using the more traditional style by default on macOS.

## UI Changes

Simple cards now use larger, narrower rank labels with top-aligned corner suits. New or unset preferences use platform-specific default card styles.

## Validation

- macOS Debug build
- Full macOS test suite: 592 passed, 10 skipped, 0 failed
- Focused `CardStyleTests`
- `git diff --check`
- Autoreview: clean