### PR TITLE
Rename redeal action to restart

### DIFF
--- a/ComputerSolitaire/GameMenuCommands.swift
+++ b/ComputerSolitaire/GameMenuCommands.swift
@@ -78,7 +78,7 @@ struct GameMenuCommands: Commands {
             Button {
                 actions?.redeal()
             } label: {
-                Label("Redeal", systemImage: "arrow.clockwise")
+                Label("Restart", systemImage: "arrow.clockwise")
             }
             .disabled(!(state?.canRedeal ?? false))
 

--- a/ComputerSolitaire/Views/Shared/ContentView.swift
+++ b/ComputerSolitaire/Views/Shared/ContentView.swift
@@ -309,7 +309,7 @@ struct ContentView: View {
                                 Button("New Game", systemImage: "plus") {
                                     startNewGameFromUI()
                                 }
-                                Button("Redeal", systemImage: "arrow.clockwise") {
+                                Button("Restart", systemImage: "arrow.clockwise") {
                                     redealFromUI()
                                 }
                                 .disabled(!viewModel.canRedeal)
@@ -412,7 +412,7 @@ struct ContentView: View {
                         Button("New Game", systemImage: "plus") {
                             startNewGameFromUI()
                         }
-                        Button("Redeal", systemImage: "arrow.clockwise") {
+                        Button("Restart", systemImage: "arrow.clockwise") {
                             redealFromUI()
                         }
                         .disabled(!viewModel.canRedeal)
@@ -420,7 +420,7 @@ struct ContentView: View {
                         Label("New Game", systemImage: "plus")
                     }
                     .labelStyle(.iconOnly)
-                    .help("New Game or Redeal")
+                    .help("New Game or Restart")
                 }
                 ToolbarSpacer(.fixed)
                 ToolbarItemGroup(placement: .primaryAction) {

--- a/ComputerSolitaire/Views/StatisticsView.swift
+++ b/ComputerSolitaire/Views/StatisticsView.swift
@@ -444,7 +444,7 @@ private struct GameStatisticsDetailView: View {
             .buttonStyle(.plain)
             .accessibilityLabel("Clean Wins info")
             .popover(isPresented: $isShowingCleanWinsInfo, arrowEdge: .top) {
-                Text("Wins completed without the use of hints, undos, or redeals.")
+                Text("Wins completed without the use of hints, undos, or restarts.")
                     .font(.callout)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: 280, alignment: .leading)

--- a/docs/rules/canfield.md
+++ b/docs/rules/canfield.md
@@ -56,7 +56,7 @@ The classic sources are unusually consistent for a patience game. The choices he
 - **Wrapping in both directions.** Foundations turn King-to-Ace and tableau builds turn Ace-to-King. Both are definitional: with a random base rank, the cards just below it would otherwise be nearly unplayable.
 - **Compulsory reserve fill.** A space takes the reserve's top card at once, not at the player's option. Choice enters only after the reserve is out, when the top waste card may fill a space (and nothing else may — not even another tableau pile).
 - **Locked foundations.** A banked card never returns to play. No classic source permits "worrying back", though some apps offer it as a house option.
-- **Draw three with unlimited redeals.** This is universal across the classic sources. Deal-one variants exist (Rainbow) but are a different, far easier game. The in-app **Redeal** command replays the same deal from the start — a fresh attempt at the layout, not the stock recycle, which is unlimited and free.
+- **Draw three with unlimited redeals.** This is universal across the classic sources. Deal-one variants exist (Rainbow) but are a different, far easier game. The in-app **Restart** command returns the same deal to its starting layout — a fresh attempt, not a stock recycle, which is unlimited and free.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Canfield_(solitaire)

--- a/docs/rules/fortythieves.md
+++ b/docs/rules/fortythieves.md
@@ -48,7 +48,7 @@ Where the linked sources offer relaxations, this implementation uses:
 - **Build down by suit**, not by alternating colors. This is the strict classic rule — color building is a different, much easier game.
 - **Any card fills an empty column** (universal across sources), and columns have no depth limit.
 - **Locked foundations.** A banked card never returns to play. Klondike-style rollbacks would soften the game's defining irreversibility.
-- **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game). The in-app **Redeal** command replays the same deal from the start — a fresh attempt at the layout, not a recycle of the stock.
+- **Single pass** through the stock with no recycles (universal across sources — the pass limit is the game). The in-app **Restart** command returns the same deal to its starting layout — a fresh attempt, not a recycle of the stock.
 
 ## Sources
 - https://en.wikipedia.org/wiki/Napoleon_at_St_Helena

--- a/docs/rules/golf.md
+++ b/docs/rules/golf.md
@@ -34,7 +34,7 @@ Rank order runs Ace, 2 … 10, Jack, Queen, King, and does **not** wrap: an Ace 
 - Clearing the board subtracts one point per stock card left, so scores below zero are the best results.
 - There is no time bonus — strokes are the whole score.
 - A match is nine consecutive holes. The totals sum, and par for the match is 45.
-- **New Game** abandons the match and starts a fresh one at hole 1. **Redeal** replays the current hole. Switching games keeps the match — every game's session is stashed, and Golf resumes where it left off.
+- **New Game** abandons the match and starts a fresh one at hole 1. **Restart** returns the current hole to its starting layout. Switching games keeps the match — every game's session is stashed, and Golf resumes where it left off.
 
 ## Winning
 You win a hole the moment the last column card is played, regardless of the stock and waste. Most holes are not winnable under strict rules (that is the classic game), so the match score is the real contest: clear what the deal allows and beat par across nine holes.


### PR DESCRIPTION
## What Changed

- Rename the player-facing Redeal action to Restart across the iOS and macOS menus.
- Update the macOS toolbar help and Clean Wins explanation to use the same terminology.
- Align the README-linked Golf, Canfield, and Forty Thieves rules with the renamed command while preserving redeal terminology for stock recycling.

## Why

Redeal commonly refers to recycling the stock in solitaire. Restart more clearly describes returning the current deal to its initial state, especially when paired with New Game.

## UI Changes

Menu copy now pairs New Game with Restart. The existing circular-arrow icon and layout are unchanged.

## Validation

- macOS Debug build succeeded with the repository build command.
- `git diff --check` passed.
- Confirmed no stale `**Redeal**` command references remain while legitimate stock-redeal terminology is preserved.
- Autoreview completed on both change sets with no accepted or actionable findings.