### PR TITLE
Add App Store link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
   <br><span style="font-family: monospace;">Computer Solitaire</span>
 </h1>
 
-Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS.
+Computer Solitaire is a fully native Solitaire app for iOS, iPadOS, and macOS. [Find it on the App Store](https://apps.apple.com/us/app/computer-solitaire/id6761316105).
 
 <p align="center">
   <img src="./docs/screenshots/screen-grab-ios.png" alt="iOS screenshot" height="420" />


### PR DESCRIPTION
## What Changed
Added a link to the Computer Solitaire App Store listing (https://apps.apple.com/us/app/computer-solitaire/id6761316105) to the README intro sentence.

## Why
The README had no way to find the published app; readers should be able to get to the App Store listing directly.

## Validation
Docs-only change; verified the link resolves to the Computer Solitaire listing. No build or test impact.